### PR TITLE
[#14] 라이브 액티비티 적용

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -3,13 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D844BCB52CC0AE770059E31F /* BusStopData.csv in Resources */ = {isa = PBXBuildFile; fileRef = D844BCB42CC0AE770059E31F /* BusStopData.csv */; };
 		5B6DA5B82CBE551400613ACB /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B72CBE551400613ACB /* MapView.swift */; };
 		5B6DA5BA2CBE6F8C00613ACB /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */; };
+		D844BCB52CC0AE770059E31F /* BusStopData.csv in Resources */ = {isa = PBXBuildFile; fileRef = D844BCB42CC0AE770059E31F /* BusStopData.csv */; };
+		D844BCBD2CC120010059E31F /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D844BCBC2CC120010059E31F /* WidgetKit.framework */; };
+		D844BCBF2CC120010059E31F /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D844BCBE2CC120010059E31F /* SwiftUI.framework */; };
+		D844BCD02CC120030059E31F /* TMTWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D844BCDA2CC147390059E31F /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D844BCD92CC147390059E31F /* LiveActivityManager.swift */; };
 		D867396D2CA933CD00FFE8ED /* TMTApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867396C2CA933CD00FFE8ED /* TMTApp.swift */; };
 		D867396F2CA933CD00FFE8ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867396E2CA933CD00FFE8ED /* ContentView.swift */; };
 		D86739712CA933CE00FFE8ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86739702CA933CE00FFE8ED /* Assets.xcassets */; };
@@ -19,10 +23,38 @@
 		D8D377ED2CBE95D10043D103 /* BusSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D377EC2CBE95D10043D103 /* BusSearchView.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		D844BCCE2CC120030059E31F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D86739612CA933CD00FFE8ED /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D844BCB92CC120010059E31F;
+			remoteInfo = TMTWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D844BCD52CC120030059E31F /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				D844BCD02CC120030059E31F /* TMTWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		D844BCB42CC0AE770059E31F /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
 		5B6DA5B72CBE551400613ACB /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		D844BCB42CC0AE770059E31F /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
+		D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TMTWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		D844BCBC2CC120010059E31F /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		D844BCBE2CC120010059E31F /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		D844BCD92CC147390059E31F /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		D86739692CA933CD00FFE8ED /* TMT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TMT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D867396C2CA933CD00FFE8ED /* TMTApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMTApp.swift; sourceTree = "<group>"; };
 		D867396E2CA933CD00FFE8ED /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -33,7 +65,37 @@
 		D8D377EC2CBE95D10043D103 /* BusSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusSearchView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D844BCD12CC120030059E31F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D844BCB92CC120010059E31F /* TMTWidgetExtension */;
+		};
+		D844BCD72CC120E40059E31F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				TMTWidgetLiveActivity.swift,
+			);
+			target = D86739682CA933CD00FFE8ED /* TMT */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D844BCC02CC120010059E31F /* TMTWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D844BCD72CC120E40059E31F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, D844BCD12CC120030059E31F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TMTWidget; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		D844BCB72CC120010059E31F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D844BCBF2CC120010059E31F /* SwiftUI.framework in Frameworks */,
+				D844BCBD2CC120010059E31F /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D86739662CA933CD00FFE8ED /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -44,10 +106,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D844BCBB2CC120010059E31F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D844BCBC2CC120010059E31F /* WidgetKit.framework */,
+				D844BCBE2CC120010059E31F /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D844BCD82CC1472E0059E31F /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				D844BCD92CC147390059E31F /* LiveActivityManager.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		D86739602CA933CD00FFE8ED = {
 			isa = PBXGroup;
 			children = (
 				D867396B2CA933CD00FFE8ED /* TMT */,
+				D844BCC02CC120010059E31F /* TMTWidget */,
+				D844BCBB2CC120010059E31F /* Frameworks */,
 				D867396A2CA933CD00FFE8ED /* Products */,
 			);
 			sourceTree = "<group>";
@@ -56,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				D86739692CA933CD00FFE8ED /* TMT.app */,
+				D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -67,6 +149,7 @@
 				D867396C2CA933CD00FFE8ED /* TMTApp.swift */,
 				D867396E2CA933CD00FFE8ED /* ContentView.swift */,
 				5B6DA5B72CBE551400613ACB /* MapView.swift */,
+				D844BCD82CC1472E0059E31F /* Utils */,
 				D8D377E72CBE95B80043D103 /* BusSearch */,
 				D8D377E42CBE548F0043D103 /* Resource */,
 				D86739702CA933CE00FFE8ED /* Assets.xcassets */,
@@ -104,6 +187,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		D844BCB92CC120010059E31F /* TMTWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D844BCD22CC120030059E31F /* Build configuration list for PBXNativeTarget "TMTWidgetExtension" */;
+			buildPhases = (
+				D844BCB62CC120010059E31F /* Sources */,
+				D844BCB72CC120010059E31F /* Frameworks */,
+				D844BCB82CC120010059E31F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D844BCC02CC120010059E31F /* TMTWidget */,
+			);
+			name = TMTWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = TMTWidgetExtension;
+			productReference = D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		D86739682CA933CD00FFE8ED /* TMT */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D86739772CA933CE00FFE8ED /* Build configuration list for PBXNativeTarget "TMT" */;
@@ -111,10 +216,12 @@
 				D86739652CA933CD00FFE8ED /* Sources */,
 				D86739662CA933CD00FFE8ED /* Frameworks */,
 				D86739672CA933CD00FFE8ED /* Resources */,
+				D844BCD52CC120030059E31F /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				D844BCCF2CC120030059E31F /* PBXTargetDependency */,
 			);
 			name = TMT;
 			productName = TMT;
@@ -128,9 +235,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1540;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
+					D844BCB92CC120010059E31F = {
+						CreatedOnToolsVersion = 16.0;
+					};
 					D86739682CA933CD00FFE8ED = {
 						CreatedOnToolsVersion = 15.4;
 					};
@@ -150,11 +260,19 @@
 			projectRoot = "";
 			targets = (
 				D86739682CA933CD00FFE8ED /* TMT */,
+				D844BCB92CC120010059E31F /* TMTWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		D844BCB82CC120010059E31F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D86739672CA933CD00FFE8ED /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -168,6 +286,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		D844BCB62CC120010059E31F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D86739652CA933CD00FFE8ED /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -179,12 +304,79 @@
 				D867396D2CA933CD00FFE8ED /* TMTApp.swift in Sources */,
 				D8D377EB2CBE95CA0043D103 /* BusSearchViewModel.swift in Sources */,
 				D8D377ED2CBE95D10043D103 /* BusSearchView.swift in Sources */,
+				D844BCDA2CC147390059E31F /* LiveActivityManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		D844BCCF2CC120030059E31F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D844BCB92CC120010059E31F /* TMTWidgetExtension */;
+			targetProxy = D844BCCE2CC120030059E31F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		D844BCD32CC120030059E31F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7P5S729LQZ;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TMTWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TMTWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = twomanythinking.TMT.TMTWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D844BCD42CC120030059E31F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7P5S729LQZ;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TMTWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TMTWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = twomanythinking.TMT.TMTWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		D86739752CA933CE00FFE8ED /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -313,10 +505,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TMT/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7P5S729LQZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We want your location haha";
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -345,10 +538,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TMT/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7P5S729LQZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We want your location haha";
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -371,6 +565,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		D844BCD22CC120030059E31F /* Build configuration list for PBXNativeTarget "TMTWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D844BCD32CC120030059E31F /* Debug */,
+				D844BCD42CC120030059E31F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D86739642CA933CD00FFE8ED /* Build configuration list for PBXProject "TMT" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/TMT/TMT.xcodeproj/xcshareddata/xcschemes/TMT.xcscheme
+++ b/TMT/TMT.xcodeproj/xcshareddata/xcschemes/TMT.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+               BuildableName = "TMT.app"
+               BlueprintName = "TMT"
+               ReferencedContainer = "container:TMT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+            BuildableName = "TMT.app"
+            BlueprintName = "TMT"
+            ReferencedContainer = "container:TMT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+            BuildableName = "TMT.app"
+            BlueprintName = "TMT"
+            ReferencedContainer = "container:TMT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TMT/TMT/BusSearch/BusSearchModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchModel.swift
@@ -9,8 +9,8 @@ struct BusStopInfo: Codable {
     var busNumber: String? // 노선명 (버스번호)
     var busType: Int? // 버스 타입
     var stopOrder: Int? // 순번
-    var stopName: String? // 정류소명 (한글)
-    var romanizedStopName: String? // 정류소명 (로마자 표기)
+    var stopNameKorean: String? // 정류소명 (한글)
+    var stopNameRomanized: String? // 정류소명 (로마자 표기)
     var xCoordinate: String? // x좌표
     var yCoordinate: String? // y좌표
 }

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -43,8 +43,8 @@ final class BusStopSearchViewModel: ObservableObject {
             self.busStops.append(BusStopInfo(busNumber: response[0].isEmpty ? nil : response[0],
                                              busType: response[1].isEmpty ? nil : Int(response[1]),
                                              stopOrder: response[2].isEmpty ? nil : Int(response[2]),
-                                             stopName: response[3].isEmpty ? nil : response[3],
-                                             romanizedStopName: response[4].isEmpty ? nil : response[4],
+                                             stopNameKorean: response[3].isEmpty ? nil : response[3],
+                                             stopNameRomanized: response[4].isEmpty ? nil : response[4],
                                              xCoordinate: response[5].isEmpty ? nil : response[5],
                                              yCoordinate: response[6].isEmpty ? nil : String(response[6].dropLast(1))))
         }

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -1,0 +1,76 @@
+//
+//  LiveActivityManager.swift
+//  TMT
+//
+//  Created by 김유빈 on 10/17/24.
+//
+
+import Combine
+import ActivityKit
+
+@available(iOS 16.2, *)
+final class LiveActivityManager: ObservableObject {
+    @Published var num: Int = 0
+    private var cancellable: Set<AnyCancellable> = Set()
+    private var activity: Activity<BusJourneyAttributes>?
+    
+    func startLiveActivity(destinationInfo: BusStopInfo) {
+        if ActivityAuthorizationInfo().areActivitiesEnabled {
+            // 실행 중인 라이브 액티비티가 있으면 종료됩니다.
+            if let _ = activity {
+                return
+            }
+            
+            guard let stopNameKorean = destinationInfo.stopNameKorean else { return }
+            guard let stropNameRomanized = destinationInfo.stopNameRomanized else { return }
+            
+            let data = BusJourneyAttributes(stopNameKorean: stopNameKorean, stopNameRomanized: stropNameRomanized)
+            
+            let initialState = BusJourneyAttributes.ContentState(remainingStopsCount: 0)
+            
+            let content = ActivityContent(state: initialState, staleDate: nil)
+            
+            do {
+                activity = try Activity.request(attributes: data, content: content)
+            } catch (let error) {
+                print("Error requesting Lockscreen Live Activity(Timer) \(error.localizedDescription).")
+            }
+        }
+        
+    }
+    
+    func endLiveActivity() {
+        let finalContent = BusJourneyAttributes.ContentState(remainingStopsCount: 0)
+        
+        let dismissalpolicy: ActivityUIDismissalPolicy = .immediate
+        
+        Task {
+            await activity?.end(ActivityContent(state: finalContent, staleDate: nil), dismissalPolicy: dismissalpolicy)
+        }
+    }
+    
+    // TODO: 값에 변화생기면 라이브 액티비티 update 하는 코드입니다.
+    // 나중에 참고하려고 넣어놨어요. 값 업데이트되면 자동으로 다이나믹 아일랜드 확장형으로 보여줍니다.
+//    func timer() {
+//        Timer.publish(every: 10, on: .main, in: .default)
+//            .autoconnect()
+//            .sink { [self] _ in
+//                num += 1
+//                Task {
+//
+//                    print(num)
+//                    let activity = self.activity
+//                    let newState = BusJourneyAttributes.ContentState(remainingStopsCount: num)
+//                    // 애플워치에서 동작
+//                    let alertConfiguration = AlertConfiguration(
+//                        title: "timer update",
+//                        body: "현재숫자: \(num)",
+//                        sound: .default
+//                    )
+//                    await activity?.update(using: newState, alertConfiguration: alertConfiguration)
+//                }
+//            }
+//            .store(in: &cancellable)
+//    }
+
+}

--- a/TMT/TMTWidget/AppIntent.swift
+++ b/TMT/TMTWidget/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  TMTWidget
+//
+//  Created by 김유빈 on 10/17/24.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/TMT/TMTWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TMT/TMTWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMTWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TMT/TMTWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMTWidget/Assets.xcassets/Contents.json
+++ b/TMT/TMTWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMTWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/TMT/TMTWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMTWidget/Info.plist
+++ b/TMT/TMTWidget/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/TMT/TMTWidget/TMTWidgetBundle.swift
+++ b/TMT/TMTWidget/TMTWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  TMTWidgetBundle.swift
+//  TMTWidget
+//
+//  Created by 김유빈 on 10/17/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct TMTWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        BusJourneyLiveActivity()
+    }
+}

--- a/TMT/TMTWidget/TMTWidgetLiveActivity.swift
+++ b/TMT/TMTWidget/TMTWidgetLiveActivity.swift
@@ -1,0 +1,82 @@
+//
+//  TMTWidgetLiveActivity.swift
+//  TMTWidget
+//
+//  Created by 김유빈 on 10/17/24.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct BusJourneyAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var remainingStopsCount: Int
+    }
+    
+    // Fixed non-changing properties about your activity go here!
+    var stopNameKorean: String
+    var stopNameRomanized: String
+}
+
+struct BusJourneyLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: BusJourneyAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack(alignment: .leading) {
+                Text("\(context.attributes.stopNameRomanized)")
+                Text("\(context.attributes.stopNameKorean)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+            
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading) {
+                        Text("\(context.attributes.stopNameRomanized)")
+                            .lineLimit(3)
+                            .multilineTextAlignment(.leading)
+                        Text("\(context.attributes.stopNameKorean)")
+                        
+                    }
+                    .padding(.vertical, 8)
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.remainingStopsCount)")
+            } minimal: {
+                Text("\(context.state.remainingStopsCount)")
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension BusJourneyAttributes {
+    fileprivate static var preview: BusJourneyAttributes {
+        BusJourneyAttributes(stopNameKorean: "효곡동행정복지센터", stopNameRomanized: "Hyo-gok-dong Haeng-jeong Bok-ji Center")
+    }
+}
+
+extension BusJourneyAttributes.ContentState {
+    fileprivate static var smiley: BusJourneyAttributes.ContentState {
+        BusJourneyAttributes.ContentState(remainingStopsCount: 5)
+    }
+    
+    fileprivate static var starEyes: BusJourneyAttributes.ContentState {
+        BusJourneyAttributes.ContentState(remainingStopsCount: 5)
+    }
+}
+
+#Preview("Notification", as: .content, using: BusJourneyAttributes.preview) {
+    BusJourneyLiveActivity()
+} contentStates: {
+    BusJourneyAttributes.ContentState.smiley
+    BusJourneyAttributes.ContentState.starEyes
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- Widget Extension 타겟 추가
- Live Activity 사용 가능하도록 `Info.plist` 설정
- Live Activity 핸들링하기 위해 `manager` 생성
  - 현재는 `start`, `end` 함수만 구현.
  - 추후 `update` 함수 구현 예정입니다.
  - 앱 내에서 라이브 액티비티는 **한 개**만 실행될 수 있도록 설정해놨습니다.

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/3e573b5f-3884-42c7-82e7-78a83dbafb2a" width="300"/>

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 해당 이슈와 관련있는 내용은 아니지만, `BusStopInfo` 구조체 중 **정류장(한글/로마자)** 프로퍼티의 변수명을 수정했습니다. 정류장 이름이라는 공통 특성이 드러나게끔 수정해봤어요.
`변경 전` stopName / romanizedStopName
`변경 후` stopNameKorean / stopNameRomanized