### PR TITLE
[#12] 버스 루트 별 정류장 띄우기

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D844BCB52CC0AE770059E31F /* BusStopData.csv in Resources */ = {isa = PBXBuildFile; fileRef = D844BCB42CC0AE770059E31F /* BusStopData.csv */; };
 		5B6DA5B82CBE551400613ACB /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B72CBE551400613ACB /* MapView.swift */; };
 		5B6DA5BA2CBE6F8C00613ACB /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */; };
+		D844BCB52CC0AE770059E31F /* BusStopData.csv in Resources */ = {isa = PBXBuildFile; fileRef = D844BCB42CC0AE770059E31F /* BusStopData.csv */; };
 		D867396D2CA933CD00FFE8ED /* TMTApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867396C2CA933CD00FFE8ED /* TMTApp.swift */; };
 		D867396F2CA933CD00FFE8ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867396E2CA933CD00FFE8ED /* ContentView.swift */; };
 		D86739712CA933CE00FFE8ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86739702CA933CE00FFE8ED /* Assets.xcassets */; };
@@ -20,9 +20,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		D844BCB42CC0AE770059E31F /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
 		5B6DA5B72CBE551400613ACB /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		D844BCB42CC0AE770059E31F /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
 		D86739692CA933CD00FFE8ED /* TMT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TMT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D867396C2CA933CD00FFE8ED /* TMTApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMTApp.swift; sourceTree = "<group>"; };
 		D867396E2CA933CD00FFE8ED /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -63,10 +63,10 @@
 		D867396B2CA933CD00FFE8ED /* TMT */ = {
 			isa = PBXGroup;
 			children = (
-				5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */,
 				D867396C2CA933CD00FFE8ED /* TMTApp.swift */,
 				D867396E2CA933CD00FFE8ED /* ContentView.swift */,
 				5B6DA5B72CBE551400613ACB /* MapView.swift */,
+				5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */,
 				D8D377E72CBE95B80043D103 /* BusSearch */,
 				D8D377E42CBE548F0043D103 /* Resource */,
 				D86739702CA933CE00FFE8ED /* Assets.xcassets */,

--- a/TMT/TMT.xcodeproj/xcshareddata/xcschemes/TMT.xcscheme
+++ b/TMT/TMT.xcodeproj/xcshareddata/xcschemes/TMT.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+               BuildableName = "TMT.app"
+               BlueprintName = "TMT"
+               ReferencedContainer = "container:TMT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+            BuildableName = "TMT.app"
+            BlueprintName = "TMT"
+            ReferencedContainer = "container:TMT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D86739682CA933CD00FFE8ED"
+            BuildableName = "TMT.app"
+            BlueprintName = "TMT"
+            ReferencedContainer = "container:TMT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TMT/TMT/BusSearch/BusSearchModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchModel.swift
@@ -5,7 +5,10 @@
 //  Created by 김유빈 on 10/15/24.
 //
 
-struct BusStopInfo: Codable {
+import Foundation
+
+struct BusStopInfo: Codable, Identifiable {
+    var id = UUID()
     var busNumber: String? // 노선명 (버스번호)
     var busType: Int? // 버스 타입
     var stopOrder: Int? // 순번

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -11,6 +11,7 @@ final class BusStopSearchViewModel: ObservableObject {
     @Published var busStops: [BusStopInfo] = []
     @Published var filteredBusStops: [BusStopInfo] = []
     @Published var busNumbers = [Int]()
+    @Published var nameAndCoordinates: [BusStop] = []
     
     init() {
         loadCSV()
@@ -72,4 +73,25 @@ final class BusStopSearchViewModel: ObservableObject {
             return nil
         }))
     }
+    
+    func getNameAndCoordinates(busNum: String) {
+        var stopInfo: [BusStop] = []
+        for busStop in busStops {
+            if busStop.busNumber == busNum {
+                if let stopName = busStop.stopName,
+                   let xCoordinate = busStop.xCoordinate,
+                   let yCoordinate = busStop.yCoordinate {
+                    stopInfo.append(BusStop(name: stopName, latitude: xCoordinate, longitude: yCoordinate))
+                }
+            }
+        }
+        nameAndCoordinates = stopInfo
+    }
+}
+
+struct BusStop: Identifiable {
+    let id = UUID()
+    let name: String
+    let latitude: String
+    let longitude: String
 }

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -11,7 +11,7 @@ final class BusStopSearchViewModel: ObservableObject {
     @Published var busStops: [BusStopInfo] = []
     @Published var filteredBusStops: [BusStopInfo] = []
     @Published var busNumbers = [Int]()
-    @Published var nameAndCoordinates: [BusStop] = []
+    @Published var nameAndCoordinates: [BusStopInfo] = []
     
     init() {
         loadCSV()
@@ -75,23 +75,16 @@ final class BusStopSearchViewModel: ObservableObject {
     }
     
     func getNameAndCoordinates(busNum: String) {
-        var stopInfo: [BusStop] = []
+        var stopInfo: [BusStopInfo] = []
         for busStop in busStops {
             if busStop.busNumber == busNum {
-                if let stopName = busStop.stopName,
+                if let stopName = busStop.romanizedStopName,
                    let xCoordinate = busStop.xCoordinate,
                    let yCoordinate = busStop.yCoordinate {
-                    stopInfo.append(BusStop(name: stopName, latitude: xCoordinate, longitude: yCoordinate))
+                    stopInfo.append(BusStopInfo(romanizedStopName: stopName, xCoordinate: xCoordinate, yCoordinate: yCoordinate))
                 }
             }
         }
         nameAndCoordinates = stopInfo
     }
-}
-
-struct BusStop: Identifiable {
-    let id = UUID()
-    let name: String
-    let latitude: String
-    let longitude: String
 }

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -11,7 +11,6 @@ final class BusStopSearchViewModel: ObservableObject {
     @Published var busStops: [BusStopInfo] = []
     @Published var filteredBusStops: [BusStopInfo] = []
     @Published var busNumbers = [Int]()
-    @Published var nameAndCoordinates: [BusStopInfo] = []
     
     init() {
         loadCSV()
@@ -58,7 +57,6 @@ final class BusStopSearchViewModel: ObservableObject {
             }
             return false
         }
-        
         fetchBusNumbersList()
     }
     
@@ -72,19 +70,5 @@ final class BusStopSearchViewModel: ObservableObject {
             }
             return nil
         }))
-    }
-    
-    func getNameAndCoordinates(busNum: String) {
-        var stopInfo: [BusStopInfo] = []
-        for busStop in busStops {
-            if busStop.busNumber == busNum {
-                if let stopName = busStop.romanizedStopName,
-                   let xCoordinate = busStop.xCoordinate,
-                   let yCoordinate = busStop.yCoordinate {
-                    stopInfo.append(BusStopInfo(romanizedStopName: stopName, xCoordinate: xCoordinate, yCoordinate: yCoordinate))
-                }
-            }
-        }
-        nameAndCoordinates = stopInfo
     }
 }

--- a/TMT/TMT/LocationManager.swift
+++ b/TMT/TMT/LocationManager.swift
@@ -1,5 +1,5 @@
 //
-//  LocationManagerDelegate.swift
+//  LocationManager.swift
 //  TMT
 //
 //  Created by Choi Minkyeong on 10/15/24.
@@ -11,7 +11,7 @@ import MapKit
 
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        center: CLLocationCoordinate2D(latitude: 36.016082, longitude: 129.324605),
         span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
     )
     

--- a/TMT/TMT/MapView.swift
+++ b/TMT/TMT/MapView.swift
@@ -10,29 +10,54 @@ import MapKit
 
 struct MapView: View {
     @StateObject private var locationManager = LocationManager()
+    @StateObject var busStopSearchViewModel = BusStopSearchViewModel()
     
+    // TODO: 사용자 위치 바뀌어도 화면 다시 업데이트 안되게 하기.
     var body: some View {
         ZStack {
-            Map(coordinateRegion: $locationManager.region, showsUserLocation: true)
-                .edgesIgnoringSafeArea(.all)
-            VStack {
-                HStack {
-                    Spacer()
-                    Button {
-                        locationManager.findCurrentLocation()
-                    } label: {
-                        ZStack {
-                            Circle()
-                                .frame(width: 40)
-                                .tint(.white)
-                                .shadow(radius: 5)
-                            Image(systemName: "location.fill")
-                                .font(.title)
-                                .tint(.gray)
-                        }
+            Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: busStopSearchViewModel.nameAndCoordinates) { stop in
+                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: Double(stop.latitude) ?? 0, longitude: Double(stop.longitude) ?? 0)) {
+                    VStack {
+                        RoundedRectangle(cornerRadius: 5)
+                            .frame(width: 30, height: 30)
+                            .foregroundStyle(.blue)
+                        Text(stop.name)
+                            .font(.caption)
+                            .foregroundColor(.black)
                     }
                 }
+            }
+            .edgesIgnoringSafeArea(.all)
+            VStack {
+                Button {
+                    busStopSearchViewModel.getNameAndCoordinates(busNum: "207(기본)")
+                } label: {
+                    Text("207번 버스")
+                        .background(.white)
+                }
+                
+                Button {
+                    busStopSearchViewModel.getNameAndCoordinates(busNum: "306(기본)")
+                } label: {
+                    Text("472번 버스")
+                        .background(.white)
+                }
+                
                 Spacer()
+                Button {
+                    locationManager.findCurrentLocation()
+                } label: {
+                    ZStack {
+                        Circle()
+                            .frame(width: 40)
+                            .tint(.white)
+                            .shadow(radius: 5)
+                        Image(systemName: "location.fill")
+                            .font(.title)
+                            .tint(.gray)
+                    }
+                }
+                
             }
             .padding()
         }

--- a/TMT/TMT/MapView.swift
+++ b/TMT/TMT/MapView.swift
@@ -14,7 +14,7 @@ struct MapView: View {
     
     var body: some View {
         ZStack {
-            Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: busStopSearchViewModel.nameAndCoordinates) { stop in
+            Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: busStopSearchViewModel.filteredBusStops) { stop in
                 MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: Double(stop.xCoordinate ?? "") ?? 0, longitude: Double(stop.yCoordinate ?? "") ?? 0)) {
                     VStack {
                         RoundedRectangle(cornerRadius: 5)
@@ -26,14 +26,14 @@ struct MapView: View {
             .edgesIgnoringSafeArea(.all)
             VStack {
                 Button {
-                    busStopSearchViewModel.getNameAndCoordinates(busNum: "207(기본)")
+                    busStopSearchViewModel.searchBusStops(by: "207(기본)")
                 } label: {
                     Text("207번 버스")
                         .background(.white)
                 }
                 
                 Button {
-                    busStopSearchViewModel.getNameAndCoordinates(busNum: "306(기본)")
+                    busStopSearchViewModel.searchBusStops(by: "306(기본)")
                 } label: {
                     Text("472번 버스")
                         .background(.white)

--- a/TMT/TMT/MapView.swift
+++ b/TMT/TMT/MapView.swift
@@ -13,17 +13,15 @@ struct MapView: View {
     @StateObject var busStopSearchViewModel = BusStopSearchViewModel()
     
     // TODO: 사용자 위치 바뀌어도 화면 다시 업데이트 안되게 하기.
+    // 투두: 다시 테스트 해보고, 밑에 스트링 값 없을 때 대신 넣는거 생각해보기.
     var body: some View {
         ZStack {
             Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: busStopSearchViewModel.nameAndCoordinates) { stop in
-                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: Double(stop.latitude) ?? 0, longitude: Double(stop.longitude) ?? 0)) {
+                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: Double(stop.xCoordinate ?? "") ?? 0, longitude: Double(stop.yCoordinate ?? "") ?? 0)) {
                     VStack {
                         RoundedRectangle(cornerRadius: 5)
                             .frame(width: 30, height: 30)
                             .foregroundStyle(.blue)
-                        Text(stop.name)
-                            .font(.caption)
-                            .foregroundColor(.black)
                     }
                 }
             }

--- a/TMT/TMT/MapView.swift
+++ b/TMT/TMT/MapView.swift
@@ -12,8 +12,6 @@ struct MapView: View {
     @StateObject private var locationManager = LocationManager()
     @StateObject var busStopSearchViewModel = BusStopSearchViewModel()
     
-    // TODO: 사용자 위치 바뀌어도 화면 다시 업데이트 안되게 하기.
-    // 투두: 다시 테스트 해보고, 밑에 스트링 값 없을 때 대신 넣는거 생각해보기.
     var body: some View {
         ZStack {
             Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: busStopSearchViewModel.nameAndCoordinates) { stop in


### PR DESCRIPTION
<!--[#이슈번호] Title
ex) [#1] PR Templete 생성
타이틀 양식 참고하고 지우기 !!-->
## 📝 작업 내용

- 207번 버튼을 누르면 207번에 해당하는 노선이 뜹니다. (참고로 472번은 위치가 멀어서 뜨지 않습니다.)
- 첫 화면이 기본 설정 좌표로 뜨는 오류, 사용자 위치로 돌아오는 버튼의 오류를 수정하였습니다.


## 💬 리뷰 요구사항(선택)

- 이전의 지도를 띄웠던 코드를 합치는 과정에서 BusStop 구조체를 생성하게 되었습니다. 구조체의 이름이 적절한가요?
- 이번 Pr에서 지도가 사용자의 현재 위치에 따라 업데이트되지 않고, 자유롭게 사용할 수 있게 하는 기능은 구현되지 않았습니다.
