### PR TITLE
[#29] MapView를 UIKit 뷰로 변환시키기

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B4F87342CC973F4000329C2 /* MapViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F87332CC973F3000329C2 /* MapViewWrapper.swift */; };
 		5B6DA5B82CBE551400613ACB /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B72CBE551400613ACB /* MapView.swift */; };
 		5B6DA5BA2CBE6F8C00613ACB /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */; };
 		5BCE45712CC3966200CF38CE /* NextStopInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCE45702CC3964F00CF38CE /* NextStopInfoView.swift */; };
@@ -49,6 +50,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5B4F87332CC973F3000329C2 /* MapViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewWrapper.swift; sourceTree = "<group>"; };
 		5B6DA5B72CBE551400613ACB /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		5BCE45702CC3964F00CF38CE /* NextStopInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextStopInfoView.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 		5BCE456F2CC389FE00CF38CE /* BusJourney */ = {
 			isa = PBXGroup;
 			children = (
+				5B4F87332CC973F3000329C2 /* MapViewWrapper.swift */,
 				5BCE45702CC3964F00CF38CE /* NextStopInfoView.swift */,
 				5B6DA5B72CBE551400613ACB /* MapView.swift */,
 			);
@@ -314,6 +317,7 @@
 				5B6DA5BA2CBE6F8C00613ACB /* LocationManager.swift in Sources */,
 				5BCE45712CC3966200CF38CE /* NextStopInfoView.swift in Sources */,
 				D867396D2CA933CD00FFE8ED /* TMTApp.swift in Sources */,
+				5B4F87342CC973F4000329C2 /* MapViewWrapper.swift in Sources */,
 				D8D377EB2CBE95CA0043D103 /* BusSearchViewModel.swift in Sources */,
 				D8D377ED2CBE95D10043D103 /* BusSearchView.swift in Sources */,
 				D844BCDA2CC147390059E31F /* LiveActivityManager.swift in Sources */,

--- a/TMT/TMT/BusJourney/MapView.swift
+++ b/TMT/TMT/BusJourney/MapView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import MapKit
 
 struct Coordinate: Identifiable {
     var id = UUID()
@@ -23,7 +22,7 @@ struct MapView: View {
     
     var body: some View {
         ZStack {
-            mapView
+            mapViewWrapper
                 .edgesIgnoringSafeArea(.all)
             controlsView
         }
@@ -37,14 +36,8 @@ struct MapView: View {
         .navigationBarItems(leading: backButton)
     }
     
-    private var mapView: some View {
-        Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: items) { stop in
-            MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: stop.xCoordinate, longitude: stop.yCoordinate)) {
-                RoundedRectangle(cornerRadius: 5)
-                    .frame(width: 40, height: 40)
-                    .foregroundStyle(.black)
-            }
-        }
+    private var mapViewWrapper: some View {
+        MapViewWrapper(region: $locationManager.region, items: items)
     }
     
     private var controlsView: some View {
@@ -86,7 +79,7 @@ struct MapView: View {
         }
     }
     
-    /// BusStopInfo를 Coordinate로 변환하는 함수
+    /// 좌표의 옵셔널을 제거합니다.
     private func getCoordinates() -> [Coordinate] {
         busStopSearchViewModel.filteredBusStops.compactMap { stop in
             guard let xCoordinate = stop.xCoordinate,

--- a/TMT/TMT/BusJourney/MapViewWrapper.swift
+++ b/TMT/TMT/BusJourney/MapViewWrapper.swift
@@ -1,0 +1,67 @@
+//
+//  MapViewWrapper.swift
+//  TMT
+//
+//  Created by Choi Minkyeong on 10/24/24.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapViewWrapper: UIViewRepresentable {
+    @Binding var region: MKCoordinateRegion
+    var items: [Coordinate]
+    
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var parent: MapViewWrapper
+        
+        init(_ parent: MapViewWrapper) {
+            self.parent = parent
+        }
+        
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            if annotation is MKUserLocation {
+                return nil
+            }
+            
+            let identifier = "BusStop"
+            var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
+            
+            if annotationView == nil {
+                annotationView = MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+                annotationView?.canShowCallout = true
+                annotationView?.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+                annotationView?.backgroundColor = .black
+                annotationView?.layer.cornerRadius = 5
+            } else {
+                annotationView?.annotation = annotation
+            }
+            return annotationView
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.showsUserLocation = true
+        mapView.userTrackingMode = .followWithHeading
+        mapView.setRegion(region, animated: true)
+        return mapView
+    }
+    
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+        mapView.setRegion(region, animated: true)
+        mapView.removeAnnotations(mapView.annotations)
+        
+        let annotations = items.map { stop in
+            let annotation = MKPointAnnotation()
+            annotation.coordinate = CLLocationCoordinate2D(latitude: stop.xCoordinate, longitude: stop.yCoordinate)
+            return annotation
+        }
+        mapView.addAnnotations(annotations)
+    }
+}

--- a/TMT/TMT/TMTApp.swift
+++ b/TMT/TMT/TMTApp.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct TMTApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+//            ContentView()
+            BusSearchView()
         }
     }
 }


### PR DESCRIPTION
<!--[#이슈번호] Title
ex) [#1] PR Templete 생성
타이틀 양식 참고하고 지우기 !!-->
## 📝 작업 내용

- 기존의 맵이 들어가는 뷰를 UIKit을 적용한 뷰로 변환하였습니다.
- 이 과정에서 MapViewWrapper라는 새로운 파일이 추가되었습니다. 
- 나타나는 뷰는 기존과 변한 점이 없습니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 원래 넣으려고 했던 heading indicator는 구현에 생각보다 어려움이 있어서 뒤로 미루었습니다. 참고로 heading indicator는 밑에 첨부한 사진과 같습니다.
![IMG_1A94643AB40C-1](https://github.com/user-attachments/assets/91bed415-65b4-4e31-aeae-d10f8754af7d)
 
