### PR TITLE
add color asset

### DIFF
--- a/TMT/TMT/Assets.xcassets/Brand/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Brand/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Brand/background.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Brand/background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0x27",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Brand/primary.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Brand/primary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x34",
+          "green" : "0xC7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.722",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Brand/primaryOpacity70.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Brand/primaryOpacity70.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x34",
+          "green" : "0xC7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0xB8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Bus/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Bus/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Bus/blue.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Bus/blue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x64",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x64",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Bus/green.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Bus/green.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xFF",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xFF",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Bus/olivegreen.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Bus/olivegreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0xB0",
+          "red" : "0x5B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0xB0",
+          "red" : "0x5B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Bus/red.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Bus/red.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3D",
+          "green" : "0x3D",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3D",
+          "green" : "0x3D",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey100.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC6",
+          "green" : "0xC6",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC6",
+          "green" : "0xC6",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey200.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAA",
+          "green" : "0xAA",
+          "red" : "0xAA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAA",
+          "green" : "0xAA",
+          "red" : "0xAA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey30.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey30.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey300.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x84",
+          "green" : "0x84",
+          "red" : "0x84"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x84",
+          "green" : "0x84",
+          "red" : "0x84"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey400.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6C",
+          "green" : "0x6C",
+          "red" : "0x6C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6C",
+          "green" : "0x6C",
+          "red" : "0x6C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey50.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey500.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0x47",
+          "red" : "0x47"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0x47",
+          "red" : "0x47"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey600.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x41",
+          "red" : "0x41"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x41",
+          "red" : "0x41"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey700.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x32",
+          "red" : "0x32"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x32",
+          "red" : "0x32"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey800.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Grey/grey900.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Grey/grey900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1E",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1E",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange100.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0xE9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0xE9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange200.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0xDE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0xDE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange300.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0xCF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0xCF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange400.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0xC6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0xC6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange50.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xF8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xF8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange500.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xB8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xB8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange600.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x9B",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x9B",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange700.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x83",
+          "red" : "0xB5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x83",
+          "red" : "0xB5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange800.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x65",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x65",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Orange/orange900.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Orange/orange900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x4D",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x4D",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red100.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0xCC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0xCC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red200.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0xB3",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0xB3",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red300.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x90",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x90",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red400.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x7A",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x7A",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red50.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xEE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xEE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red500.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x59",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x59",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red600.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red700.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xB4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xB4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red800.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x01",
+          "green" : "0x01",
+          "red" : "0x89"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x01",
+          "green" : "0x01",
+          "red" : "0x89"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Red/red900.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Red/red900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x41"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x41"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow100.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC0",
+          "green" : "0xEE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC0",
+          "green" : "0xEE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow200.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0xE5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0xE5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow300.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xD9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xD9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow400.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5D",
+          "green" : "0xD2",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5D",
+          "green" : "0xD2",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow50.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xF9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xF9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow500.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x34",
+          "green" : "0xC7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x34",
+          "green" : "0xC7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow600.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0xB5",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0xB5",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow700.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x8D",
+          "red" : "0xB5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x8D",
+          "red" : "0xB5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow800.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x6D",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x6D",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow900.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/Yellow/yellow900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x16",
+          "green" : "0x54",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x16",
+          "green" : "0x54",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/black.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/blackOpacity40.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/blackOpacity40.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/blackOpacity60.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/blackOpacity60.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/blackOpacity80.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/blackOpacity80.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0x27",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0x27",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/white.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/white.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/Foundation/whiteOpacity30.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/Foundation/whiteOpacity30.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left1.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left1Opacity.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left1Opacity.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left2.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.349",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.349",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left2Opacity.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left2Opacity.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x58",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x58",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left3.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.608",
+          "red" : "0.988"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.608",
+          "red" : "0.988"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/left3Opacity.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/left3Opacity.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x9B",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x9B",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/ready.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/ready.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TMT/TMT/Assets.xcassets/StopLeft/readyOpacity.colorset/Contents.json
+++ b/TMT/TMT/Assets.xcassets/StopLeft/readyOpacity.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/convert_tokens_to_assets.py
+++ b/convert_tokens_to_assets.py
@@ -1,0 +1,152 @@
+import os
+import json
+
+
+# colors처럼 글로벌 네임 컬러와 시멘틱 내임 컬러가 모두 들어가 있는 파일이 필요하다 -> 이 시멘틱 네임 컬러랑, 글로벌 컬러가 다른 파일에 있어도 처리할 수 있도록 만들어야 한다
+# design tokens 플러그인용
+# design tokens의 Settings의 NameSetting이 디폴트여야함 (스네이크, 카멜케이스면 안됨)
+# 다른 경로에 둔 다음 엑스코드 프로젝트에 직접 추가할것 (경로 문제  떄문에)
+# 컬러(시멘틱 네임 컬러, 글로벌 네임 컬러)가 들어가 있는 컬렉션명을 꼭 color_location에 모두 넣을것
+# json 파일위치 파일생성 위치를 모두 지정할 것
+
+
+# JSON file 불러오기
+def load_json_file(file_path):
+    with open(file_path, 'r') as file:
+        return json.load(file)
+
+def hex_to_rgba(hex_value):
+    hex_value = hex_value.lstrip('#')
+    
+    # HEX 값의 길이가 6자리 또는 8자리일 경우만 처리
+    if len(hex_value) not in (6, 8):
+        raise ValueError("Invalid HEX value. HEX code must be 6 or 8 characters long.")
+    
+    # 6자리인 경우에는 alpha 값을 기본적으로 1.0으로 설정
+    red = int(hex_value[0:2], 16)
+    green = int(hex_value[2:4], 16)
+    blue = int(hex_value[4:6], 16)
+    alpha = int(hex_value[6:8], 16) if len(hex_value) == 8 else 255  # 255는 1.0과 동일
+    
+    return {
+        "red": round(red / 255.0, 8),
+        "green": round(green / 255.0, 8),
+        "blue": round(blue / 255.0, 8),
+        "alpha": round(alpha / 255.0, 8)
+    }
+
+
+# 색상 데이터를 추출하고, RGB 값으로 변환된 색상 딕셔너리와 나머지 요소 리스트를 반환하는 함수
+def extract_and_convert_color_data(json_file_path="design-tokens.tokens.json", color_locations=None, categories=None):
+    # JSON 파일 로드
+    if isinstance(json_file_path, str):
+        data = load_json_file(json_file_path)
+    else:
+        data = json_file_path
+
+    # color_locations가 리스트일 경우 처리
+    if not isinstance(color_locations, list):
+        color_locations = [color_locations]
+
+    rgb_colors = {}
+    remaining_items = []
+    
+    # 각 컬러 폴더를 순회하며 데이터를 처리
+    for color_location in color_locations:
+        color_raw_data = data.get(color_location, {})
+        
+        # 색상 데이터 추출
+        extract_colors_from_folder(color_raw_data, rgb_colors, remaining_items, categories)
+    
+    return rgb_colors, remaining_items
+
+
+# 특정 폴더 내 색상 데이터를 처리하는 재귀 함수
+def extract_colors_from_folder(color_raw_data, rgb_colors, remaining_items, categories=None):
+    if categories is None:
+        categories = []
+
+    for key, value in color_raw_data.items():
+        current_path = categories + [key]  # 경로 추적
+        if isinstance(value, dict) and 'value' not in value:
+            # 'value'가 없으면 재귀적으로 더 깊이 탐색
+            extract_colors_from_folder(value, rgb_colors, remaining_items, current_path)
+        else:
+            # 'value'가 있는 경우 HEX 값을 RGB로 변환하거나 나머지 요소로 처리
+            hex_value = value.get("value")
+            if hex_value and hex_value.startswith('#'):
+                # HEX 형식의 값만 변환
+                rgba_value = hex_to_rgba(hex_value)  # HEX to RGBA 변환
+                rgb_value = (rgba_value["red"], rgba_value["green"], rgba_value["blue"], rgba_value["alpha"])
+                # 경로의 마지막 키(색상 이름)만 사용
+                color_name = key
+                rgb_colors[color_name] = rgb_value
+            else:
+                # 나머지 요소는 리스트에 추가
+                remaining_items.append({
+                    "path": current_path,
+                    "item_name": key,
+                    "value": value.get("value"),
+                    "type": value.get("type")
+                })
+
+
+# 경로와 파일 이름에 따른 폴더 생성 함수 및 Contents.json 파일 작성
+def create_folders_and_generate_json(rgb_colors, remaining_items, base_path):
+    for item in remaining_items:
+        path_list = item['path'][:-1]  # 마지막 경로 제외
+        folder_path = os.path.join(base_path, *path_list)  # 기본 경로와 결합
+        final_folder_name = item['path'][-1] + '.colorset'  # 마지막 항목에 .colorset 붙이기
+        final_folder_path = os.path.join(folder_path, final_folder_name)
+        # 폴더가 없으면 생성
+        if not os.path.exists(final_folder_path):
+            os.makedirs(final_folder_path)
+
+        # 컬러 값이 {colors.default.foundation.black.black-6} 같은 참조일 경우 처리
+        color_reference = item['value']
+        if color_reference and color_reference.startswith("{colors"):
+            # 참조를 추출하여 RGB 색상이 존재하는지 확인
+            color_key = color_reference.strip("{}").split(".")[-1]  # 'black-6' 추출
+            if color_key in rgb_colors:
+                rgb = rgb_colors[color_key]
+
+                # Contents.json 파일 생성
+                color_json = {
+                    "colors": [
+                        {
+                            "color": {
+                                "color-space": "srgb",
+                                "components": {
+                                    "red": f"{rgb[0]:.8f}",
+                                    "green": f"{rgb[1]:.8f}",
+                                    "blue": f"{rgb[2]:.8f}",
+                                    "alpha": f"{rgb[3]:.8f}"
+                                }
+                            },
+                            "idiom": "universal"
+                        }
+                    ],
+                    "info": {
+                        "author": "xcode",
+                        "version": 1
+                    }
+                }
+
+                # Contents.json 파일을 해당 폴더에 작성
+                contents_json_path = os.path.join(final_folder_path, "Contents.json")
+                with open(contents_json_path, 'w') as json_file:
+                    json.dump(color_json, json_file, indent=4)
+            else:
+                print(f"Color key {color_key} not found in rgb_colors")
+
+
+def design_tokens_plugin_main(file_path="design-tokens.tokens.json", color_location=["colors"], base_file_path="/Users/sunyoung/Downloads/6_MacC/2024-MacC-A1-2manythinking/TMT/TMT/Assets.xcassets"):
+    color_lst, var_items = extract_and_convert_color_data(file_path, color_location)
+    create_folders_and_generate_json(color_lst, var_items, base_file_path)
+
+# 실행 예시
+file_path = "design-tokens.tokens.json"
+color_location = ["colors"]
+base_file_path = "/Users/sunyoung/Downloads/6_MacC/2024-MacC-A1-2manythinking/TMT/TMT/Assets.xcassets"
+
+design_tokens_plugin_main(file_path, color_location, base_file_path)

--- a/design-tokens.tokens.json
+++ b/design-tokens.tokens.json
@@ -1,0 +1,3577 @@
+{
+  "gradient": {
+    "ㅇㅇㅇㅇ": {
+      "description": "",
+      "type": "custom-gradient",
+      "value": {
+        "gradientType": "linear",
+        "rotation": 90,
+        "stops": [
+          {
+            "position": 0,
+            "color": "#fc9b00ff"
+          },
+          {
+            "position": 0.77,
+            "color": "#fc9b0000"
+          }
+        ]
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:749f1e337d4a794fc112b4f7cc0e85df8098f901,",
+          "exportKey": "gradient"
+        }
+      }
+    }
+  },
+  "color": {
+    "foundation": {
+      "white_opacity-30": {
+        "description": "",
+        "type": "color",
+        "value": "#ffffff4d",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:c9c3f4d36e04b52d5a3af3077a658abbd9414a19,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "white": {
+        "description": "",
+        "type": "color",
+        "value": "#ffffffff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:1d4cce6655aac2c457f71f1ea780d03205cef2d7,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "black": {
+        "description": "",
+        "type": "color",
+        "value": "#000000ff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:0c21272eee2c356d0cb7b0ce79cdea875ef7d2da,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "grey": {
+        "grey-30": {
+          "description": "",
+          "type": "color",
+          "value": "#f8f8f8ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:7556a2261df5bbe5aef3ab8e46c8e55b11b1c4d9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-50": {
+          "description": "",
+          "type": "color",
+          "value": "#f4f4f4ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6e5fb8b926c7f1e6b90072f5cabfb06528b08a60,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-100": {
+          "description": "",
+          "type": "color",
+          "value": "#c6c6c6ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:dc6d8f81d6c0bb5516134f00f0fcbe30cfaff059,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-200": {
+          "description": "",
+          "type": "color",
+          "value": "#aaaaaaff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:74a4937cb43be40be0198738faa866f59c0301a7,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-300": {
+          "description": "",
+          "type": "color",
+          "value": "#848484ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:7c0500c1fd601dc40eeb2df29236e57305a66c1d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-400": {
+          "description": "",
+          "type": "color",
+          "value": "#6c6c6cff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:4be756cc48aee0aa261395c9355f340878557b44,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-500": {
+          "description": "",
+          "type": "color",
+          "value": "#474747ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:4b365444a376327e593812692e658a6df14d3862,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-600": {
+          "description": "",
+          "type": "color",
+          "value": "#414141ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:653d074d9e251c24c8dc7f593dea23aecc2ec8e3,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-700": {
+          "description": "",
+          "type": "color",
+          "value": "#323232ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a1009a588c1da7d01ea51754396445b5fbe71b05,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-800": {
+          "description": "",
+          "type": "color",
+          "value": "#272727ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:8bb24eaaa26dd6aea695a94d2500b02a7e1aa378,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "grey-900": {
+          "description": "",
+          "type": "color",
+          "value": "#1e1e1eff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:24149550ad8c5895659e17afdbea245da20c87dd,",
+              "exportKey": "color"
+            }
+          }
+        }
+      },
+      "yellow": {
+        "yellow-50": {
+          "description": "",
+          "type": "color",
+          "value": "#fff9ebff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:dd97014e4796a60a92188d86ad77a26f3dd43c3b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-100": {
+          "description": "",
+          "type": "color",
+          "value": "#ffeec0ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:5b91483ce8710401c7a6e6f98a1eba83d9bed9c8,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-200": {
+          "description": "",
+          "type": "color",
+          "value": "#ffe5a2ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:011fbe478097fedaafdd8dbb1f7dbb6ab0e446be,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-300": {
+          "description": "",
+          "type": "color",
+          "value": "#ffd977ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d280db0e607456713a2a80368c41d01db6b67395,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-400": {
+          "description": "",
+          "type": "color",
+          "value": "#ffd25dff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:e4949bc4b5b1ffdfc247d692ff4905e3251ca262,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-500": {
+          "description": "",
+          "type": "color",
+          "value": "#ffc734ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:384034f407d59ed33076d00eb8f2680a2cc326b9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-600": {
+          "description": "",
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:3de4f92298e1f42b687f2365a7ed04c7e04d5a58,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-700": {
+          "description": "",
+          "type": "color",
+          "value": "#b58d25ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6cdbffb5adad4b5091c0df191e1c35ef10dad0df,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-800": {
+          "description": "",
+          "type": "color",
+          "value": "#8c6d1dff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:8fcc8379b29d0ab171e5b27d55355248664963f2,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "yellow-900": {
+          "description": "",
+          "type": "color",
+          "value": "#6b5416ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:3896bf517e090d381b74d86bd4c5e7582c0bf491,",
+              "exportKey": "color"
+            }
+          }
+        }
+      },
+      "orange": {
+        "orange-50": {
+          "description": "",
+          "type": "color",
+          "value": "#fff8e6ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:56a2a05eabef1284fddcdea03af911b5b9434e38,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-100": {
+          "description": "",
+          "type": "color",
+          "value": "#ffe9b0ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:630b5faf1092160b8ee24646e08fb1dd4ba074a7,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-200": {
+          "description": "",
+          "type": "color",
+          "value": "#ffde8aff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:35d611f139befba3346669338d45edf7ef85c106,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-300": {
+          "description": "",
+          "type": "color",
+          "value": "#ffcf54ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:ba660fb6a031f87a296de6cfbb14ee94a64b01dd,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-400": {
+          "description": "",
+          "type": "color",
+          "value": "#ffc633ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:2e6543260f2ed3d5046eb9efdf64232f68c1b056,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-500": {
+          "description": "",
+          "type": "color",
+          "value": "#ffb800ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:f2879d5eac0b5aa13b0acb244ea95cec174a0b87,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-600": {
+          "description": "",
+          "type": "color",
+          "value": "#fc9b00ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:ceeaccde5328115376c51265794c593f53ba672b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-700": {
+          "description": "",
+          "type": "color",
+          "value": "#b58300ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:48dcf235b2511ead1ca7156c6fbcd2adbb8aa93b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-800": {
+          "description": "",
+          "type": "color",
+          "value": "#8c6500ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:ce9cb46cca252ab4cb3632e240c271c58d1249b7,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "orange-900": {
+          "description": "",
+          "type": "color",
+          "value": "#6b4d00ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:671b9d2aa8d49e290330b10525beb149948e7d42,",
+              "exportKey": "color"
+            }
+          }
+        }
+      },
+      "red": {
+        "red-50": {
+          "description": "",
+          "type": "color",
+          "value": "#ffeee6ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:acf3450ecaa8e085df436dc555adb25c527433f9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-100": {
+          "description": "",
+          "type": "color",
+          "value": "#ffccb0ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a4f8ff2e8f9e5c037d14c5ce145885ac4828383f,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-200": {
+          "description": "",
+          "type": "color",
+          "value": "#ffb38aff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:f676ebc66b0beee902c2419c874274b335dde8ac,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-300": {
+          "description": "",
+          "type": "color",
+          "value": "#ff9054ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:425a459d041d4eeec135db8e70c874c51b227d5e,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-400": {
+          "description": "",
+          "type": "color",
+          "value": "#ff7a33ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:f0bd6b06fbd96d5d92e47cc3701f46f37fe1ef75,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-500": {
+          "description": "",
+          "type": "color",
+          "value": "#ff5900ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:06bad45b1ce2d1cb50426487cfa3260b397b3803,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-600": {
+          "description": "",
+          "type": "color",
+          "value": "#f20000ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:26143e32b6bce91c86ffa3af46c89172fba29a22,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-700": {
+          "description": "",
+          "type": "color",
+          "value": "#b40000ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a79be1c573d77d6f3d191496d8dd1320dff96a9a,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-800": {
+          "description": "",
+          "type": "color",
+          "value": "#890101ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:c9dade77c6e5ca1481ab23c9a54773bf8a971a8b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "red-900": {
+          "description": "",
+          "type": "color",
+          "value": "#410000ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:c34ac716b2ea8c3259b387170069411ee679e036,",
+              "exportKey": "color"
+            }
+          }
+        }
+      }
+    },
+    "bus": {
+      "red": {
+        "description": "서울 광역버스",
+        "type": "color",
+        "value": "#cc3d3dff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:a2f64d101f53205627c8ed652e14233902e10274,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "blue": {
+        "description": "서울 간선버스",
+        "type": "color",
+        "value": "#0064ffff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:e3af11a5253a52286b92a16db1bc690809212e31,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "green": {
+        "description": "서울 지선,마을버스",
+        "type": "color",
+        "value": "#00ff00ff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:c7e4aaa4411e75abe74b25dbe17ae42bcdce2be7,",
+            "exportKey": "color"
+          }
+        }
+      },
+      "olive green": {
+        "description": "서울 순환버스",
+        "type": "color",
+        "value": "#5bb025ff",
+        "blendMode": "normal",
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:74db17fda084c52f1d010f0f621e7b5b710de673,",
+            "exportKey": "color"
+          }
+        }
+      }
+    }
+  },
+  "grid": {
+    "margin_16px": {
+      "0": {
+        "type": "custom-grid",
+        "value": {
+          "pattern": "columns",
+          "sectionSize": 16,
+          "gutterSize": 20,
+          "alignment": "min",
+          "count": 1,
+          "offset": 0
+        }
+      },
+      "1": {
+        "type": "custom-grid",
+        "value": {
+          "pattern": "columns",
+          "sectionSize": 16,
+          "gutterSize": 20,
+          "alignment": "max",
+          "count": 1,
+          "offset": 0
+        }
+      },
+      "description": null,
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:836c868a2c76525a22cfd2ad8b89cbe674eb4ab6,",
+          "exportKey": "grid"
+        }
+      }
+    }
+  },
+  "font": {
+    "title": {
+      "title 1": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 28,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 600,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": -0.2,
+          "lineHeight": 32,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:b04695b1f38a63db80f1a47c790370c9c2dffbd8,",
+            "exportKey": "font"
+          }
+        }
+      },
+      "title 2": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 24,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 700,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": -0.2,
+          "lineHeight": 29,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:c5d0d37acfa9f9931498763be9709a701119013d,",
+            "exportKey": "font"
+          }
+        }
+      },
+      "title 3": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 22,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 700,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": -0.2,
+          "lineHeight": 26,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:e184feb54b6ec5107e9385a3acac3e59b67afe78,",
+            "exportKey": "font"
+          }
+        }
+      },
+      "title 5": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 20,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 400,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": -0.45,
+          "lineHeight": 25,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:cf6b8d1896035a18d1d87eb28c9e64e3d43f68a9,",
+            "exportKey": "font"
+          }
+        }
+      }
+    },
+    "body": {
+      "body 1": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 18,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 500,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": -0.2,
+          "lineHeight": 23,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:b3e56b1befa4adc428b035a512c36e92e77f8695,",
+            "exportKey": "font"
+          }
+        }
+      },
+      "body 2": {
+        "medium": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 16,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 500,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0,
+            "lineHeight": 21,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:390e75d14aac989fa6244e5bbebdcaf6363d2833,",
+              "exportKey": "font"
+            }
+          }
+        },
+        "regular": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 16,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 400,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0,
+            "lineHeight": 21,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:91d246484a3dea4ec505f76c53f0e19071cb9588,",
+              "exportKey": "font"
+            }
+          }
+        }
+      }
+    },
+    "label": {
+      "label2": {
+        "type": "custom-fontStyle",
+        "value": {
+          "fontSize": 13,
+          "textDecoration": "none",
+          "fontFamily": "Pretendard",
+          "fontWeight": 400,
+          "fontStyle": "normal",
+          "fontStretch": "normal",
+          "letterSpacing": 0,
+          "lineHeight": 17,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "textCase": "none"
+        },
+        "extensions": {
+          "org.lukasoppermann.figmaDesignTokens": {
+            "styleId": "S:7aae20bf0f7f7573ab5bd4ef07cfd967bd6bd921,",
+            "exportKey": "font"
+          }
+        }
+      },
+      "label 1": {
+        "medium": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 14,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 500,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0,
+            "lineHeight": 19,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:97384897cb8b9ae35340975a2f4b6a0ffaa38aa6,",
+              "exportKey": "font"
+            }
+          }
+        },
+        "regular": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 14,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 400,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0,
+            "lineHeight": 19,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6d196b9000a336bec417e95c1c6f3e74f4e88a00,",
+              "exportKey": "font"
+            }
+          }
+        },
+        "semibold": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 14,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 600,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0,
+            "lineHeight": 19,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:c2516cce10468b484ba89d6fca5359f3b4cfb8fb,",
+              "exportKey": "font"
+            }
+          }
+        }
+      },
+      "label 3": {
+        "regular": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 12,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 400,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0.2,
+            "lineHeight": 17,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:99959a9b9d8bf01208dd1b4a1b27e94915529f96,",
+              "exportKey": "font"
+            }
+          }
+        },
+        "semibold": {
+          "type": "custom-fontStyle",
+          "value": {
+            "fontSize": 12,
+            "textDecoration": "none",
+            "fontFamily": "Pretendard",
+            "fontWeight": 600,
+            "fontStyle": "normal",
+            "fontStretch": "normal",
+            "letterSpacing": 0.2,
+            "lineHeight": 17,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "textCase": "none"
+          },
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a4c4db8eb62c6ed896da66559a05e4a7b73385bd,",
+              "exportKey": "font"
+            }
+          }
+        }
+      }
+    }
+  },
+  "effect": {
+    "card drop shadow": {
+      "description": null,
+      "type": "custom-shadow",
+      "value": {
+        "shadowType": "dropShadow",
+        "radius": 5,
+        "color": "#00000040",
+        "offsetX": 0,
+        "offsetY": 2,
+        "spread": 0
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:118f5bf933b02a84365b14b0bc93d48dd32bde0e,",
+          "exportKey": "effect"
+        }
+      }
+    },
+    "list drop shadow": {
+      "description": null,
+      "type": "custom-shadow",
+      "value": {
+        "shadowType": "dropShadow",
+        "radius": 16,
+        "color": "#0000000f",
+        "offsetX": 0,
+        "offsetY": 4,
+        "spread": 0
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:33552bae67e6e0dcf6e0e195414d8f2389efc89f,",
+          "exportKey": "effect"
+        }
+      }
+    },
+    "background blur": {
+      "description": null,
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:109a5c3c96fe8c8dd6758f851314f52d17c91b2f,",
+          "exportKey": "effect"
+        }
+      }
+    },
+    "stop name": {
+      "0": null,
+      "1": {
+        "type": "custom-shadow",
+        "value": {
+          "shadowType": "dropShadow",
+          "radius": 8,
+          "color": "#00000040",
+          "offsetX": 0,
+          "offsetY": 2,
+          "spread": 0
+        }
+      },
+      "description": null,
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:584f9f3f92f5cdaca2df0e9398f46ffb2c3fdb5c,",
+          "exportKey": "effect"
+        }
+      }
+    }
+  },
+  "colors": {
+    "light": {
+      "foundation": {
+        "white_opacity-30": {
+          "type": "color",
+          "value": "#ffffff4d",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15936",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "white": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15937",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "black": {
+          "type": "color",
+          "value": "#000000ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15938",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "grey": {
+          "grey-30": {
+            "type": "color",
+            "value": "#f8f8f8ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15939",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-50": {
+            "type": "color",
+            "value": "#f4f4f4ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15940",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-100": {
+            "type": "color",
+            "value": "#c6c6c6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15941",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-200": {
+            "type": "color",
+            "value": "#aaaaaaff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15942",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-300": {
+            "type": "color",
+            "value": "#848484ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15943",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-400": {
+            "type": "color",
+            "value": "#6c6c6cff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15944",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-500": {
+            "type": "color",
+            "value": "#474747ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15945",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-600": {
+            "type": "color",
+            "value": "#414141ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15946",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-700": {
+            "type": "color",
+            "value": "#323232ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15947",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-800": {
+            "type": "color",
+            "value": "#272727ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15948",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-900": {
+            "type": "color",
+            "value": "#1e1e1eff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15949",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "yellow": {
+          "yellow-50": {
+            "type": "color",
+            "value": "#fff9ebff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15950",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-100": {
+            "type": "color",
+            "value": "#ffeec0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15951",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-200": {
+            "type": "color",
+            "value": "#ffe5a2ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15952",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-300": {
+            "type": "color",
+            "value": "#ffd977ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15953",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-400": {
+            "type": "color",
+            "value": "#ffd25dff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15954",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-500": {
+            "type": "color",
+            "value": "#ffc734ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15955",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-600": {
+            "type": "color",
+            "value": "#e8b52fff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15956",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-700": {
+            "type": "color",
+            "value": "#b58d25ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15957",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-800": {
+            "type": "color",
+            "value": "#8c6d1dff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15958",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-900": {
+            "type": "color",
+            "value": "#6b5416ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15959",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "orange": {
+          "orange-50": {
+            "type": "color",
+            "value": "#fff8e6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15960",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-100": {
+            "type": "color",
+            "value": "#ffe9b0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15961",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-200": {
+            "type": "color",
+            "value": "#ffde8aff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15962",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-300": {
+            "type": "color",
+            "value": "#ffcf54ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15963",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-400": {
+            "type": "color",
+            "value": "#ffc633ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15964",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-500": {
+            "type": "color",
+            "value": "#ffb800ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15965",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-600": {
+            "type": "color",
+            "value": "#fc9b00ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15966",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-700": {
+            "type": "color",
+            "value": "#b58300ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15967",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-800": {
+            "type": "color",
+            "value": "#8c6500ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15968",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-900": {
+            "type": "color",
+            "value": "#6b4d00ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15969",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "black_opacity-80": {
+          "type": "color",
+          "value": "#272727cc",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15977",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "black_opacity-60": {
+          "type": "color",
+          "value": "#00000099",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15979",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "red": {
+          "red-50": {
+            "type": "color",
+            "value": "#ffeee6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10144",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-100": {
+            "type": "color",
+            "value": "#ffccb0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10145",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-200": {
+            "type": "color",
+            "value": "#ffb38aff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10146",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-300": {
+            "type": "color",
+            "value": "#ff9054ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10147",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-400": {
+            "type": "color",
+            "value": "#ff7a33ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10148",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-500": {
+            "type": "color",
+            "value": "#ff5900ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10149",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-600": {
+            "type": "color",
+            "value": "#f20000ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10150",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-700": {
+            "type": "color",
+            "value": "#b40000ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10151",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-800": {
+            "type": "color",
+            "value": "#890101ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10152",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-900": {
+            "type": "color",
+            "value": "#410000ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "light",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10191",
+                "exportKey": "variables"
+              }
+            }
+          }
+        }
+      },
+      "bus": {
+        "red": {
+          "type": "color",
+          "value": "#cc3d3dff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15970",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "blue": {
+          "type": "color",
+          "value": "#0064ffff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15971",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "green": {
+          "type": "color",
+          "value": "#00ff00ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15972",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "olivegreen": {
+          "type": "color",
+          "value": "#5bb025ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15973",
+              "exportKey": "variables"
+            }
+          }
+        }
+      },
+      "brand color": {
+        "brand": {
+          "type": "color",
+          "value": "{colors.light.foundation.yellow.yellow-500}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15974",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "background": {
+          "type": "color",
+          "value": "{colors.light.foundation.black_opacity-80}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15978",
+              "exportKey": "variables"
+            }
+          }
+        }
+      },
+      "left": {
+        "left-3": {
+          "type": "color",
+          "value": "{colors.light.foundation.orange.orange-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10250",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-2": {
+          "type": "color",
+          "value": "{colors.light.foundation.red.red-500}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10251",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-1": {
+          "type": "color",
+          "value": "{colors.light.foundation.red.red-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10252",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "ready": {
+          "type": "color",
+          "value": "{colors.light.foundation.red.red-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10253",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-3-opacity": {
+          "type": "color",
+          "value": "#fc9b00b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10258",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-2-opacity": {
+          "type": "color",
+          "value": "#ff5900b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10259",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-1-opacity": {
+          "type": "color",
+          "value": "#f20000b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10260",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "ready-opacity": {
+          "type": "color",
+          "value": "#f20000b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "light",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10261",
+              "exportKey": "variables"
+            }
+          }
+        }
+      }
+    },
+    "dark": {
+      "foundation": {
+        "white_opacity-30": {
+          "type": "color",
+          "value": "#ffffff4d",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15936",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "white": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15937",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "black": {
+          "type": "color",
+          "value": "#000000ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15938",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "grey": {
+          "grey-30": {
+            "type": "color",
+            "value": "#f8f8f8ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15939",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-50": {
+            "type": "color",
+            "value": "#f4f4f4ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15940",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-100": {
+            "type": "color",
+            "value": "#c6c6c6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15941",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-200": {
+            "type": "color",
+            "value": "#aaaaaaff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15942",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-300": {
+            "type": "color",
+            "value": "#848484ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15943",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-400": {
+            "type": "color",
+            "value": "#6c6c6cff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15944",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-500": {
+            "type": "color",
+            "value": "#474747ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15945",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-600": {
+            "type": "color",
+            "value": "#414141ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15946",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-700": {
+            "type": "color",
+            "value": "#323232ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15947",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-800": {
+            "type": "color",
+            "value": "#272727ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15948",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "grey-900": {
+            "type": "color",
+            "value": "#1e1e1eff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15949",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "yellow": {
+          "yellow-50": {
+            "type": "color",
+            "value": "#fff9ebff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15950",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-100": {
+            "type": "color",
+            "value": "#ffeec0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15951",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-200": {
+            "type": "color",
+            "value": "#ffe5a2ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15952",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-300": {
+            "type": "color",
+            "value": "#ffd977ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15953",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-400": {
+            "type": "color",
+            "value": "#ffd25dff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15954",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-500": {
+            "type": "color",
+            "value": "#ffc734ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15955",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-600": {
+            "type": "color",
+            "value": "#e8b52fff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15956",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-700": {
+            "type": "color",
+            "value": "#b58d25ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15957",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-800": {
+            "type": "color",
+            "value": "#8c6d1dff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15958",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "yellow-900": {
+            "type": "color",
+            "value": "#6b5416ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15959",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "orange": {
+          "orange-50": {
+            "type": "color",
+            "value": "#fff8e6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15960",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-100": {
+            "type": "color",
+            "value": "#ffe9b0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15961",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-200": {
+            "type": "color",
+            "value": "#ffde8aff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15962",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-300": {
+            "type": "color",
+            "value": "#ffcf54ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15963",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-400": {
+            "type": "color",
+            "value": "#ffc633ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15964",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-500": {
+            "type": "color",
+            "value": "#ffb800ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15965",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-600": {
+            "type": "color",
+            "value": "#fc9b00ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15966",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-700": {
+            "type": "color",
+            "value": "#b58300ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15967",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-800": {
+            "type": "color",
+            "value": "#8c6500ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15968",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "orange-900": {
+            "type": "color",
+            "value": "#6b4d00ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:1937:15969",
+                "exportKey": "variables"
+              }
+            }
+          }
+        },
+        "black_opacity-80": {
+          "type": "color",
+          "value": "#272727cc",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15977",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "black_opacity-60": {
+          "type": "color",
+          "value": "#00000099",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15979",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "red": {
+          "red-50": {
+            "type": "color",
+            "value": "#ffeee6ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10144",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-100": {
+            "type": "color",
+            "value": "#ffccb0ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10145",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-200": {
+            "type": "color",
+            "value": "#ffb38aff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10146",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-300": {
+            "type": "color",
+            "value": "#ff9054ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10147",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-400": {
+            "type": "color",
+            "value": "#ff7a33ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10148",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-500": {
+            "type": "color",
+            "value": "#ff5900ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10149",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-600": {
+            "type": "color",
+            "value": "#f20000ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10150",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-700": {
+            "type": "color",
+            "value": "#b40000ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10151",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-800": {
+            "type": "color",
+            "value": "#890101ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10152",
+                "exportKey": "variables"
+              }
+            }
+          },
+          "red-900": {
+            "type": "color",
+            "value": "#441100ff",
+            "blendMode": "normal",
+            "extensions": {
+              "org.lukasoppermann.figmaDesignTokens": {
+                "mode": "dark",
+                "collection": "Colors",
+                "scopes": [
+                  "ALL_SCOPES"
+                ],
+                "variableId": "VariableID:2079:10191",
+                "exportKey": "variables"
+              }
+            }
+          }
+        }
+      },
+      "bus": {
+        "red": {
+          "type": "color",
+          "value": "#cc3d3dff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15970",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "blue": {
+          "type": "color",
+          "value": "#0064ffff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15971",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "green": {
+          "type": "color",
+          "value": "#00ff00ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15972",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "olivegreen": {
+          "type": "color",
+          "value": "#5bb025ff",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15973",
+              "exportKey": "variables"
+            }
+          }
+        }
+      },
+      "brand color": {
+        "brand": {
+          "type": "color",
+          "value": "{colors.dark.foundation.orange.orange-500}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15974",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "background": {
+          "type": "color",
+          "value": "{colors.dark.foundation.black_opacity-60}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:1937:15978",
+              "exportKey": "variables"
+            }
+          }
+        }
+      },
+      "left": {
+        "left-3": {
+          "type": "color",
+          "value": "{colors.dark.foundation.orange.orange-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10250",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-2": {
+          "type": "color",
+          "value": "{colors.dark.foundation.red.red-500}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10251",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-1": {
+          "type": "color",
+          "value": "{colors.dark.foundation.red.red-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10252",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "ready": {
+          "type": "color",
+          "value": "{colors.dark.foundation.red.red-600}",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10253",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-3-opacity": {
+          "type": "color",
+          "value": "#fc9b00b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10258",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-2-opacity": {
+          "type": "color",
+          "value": "#ff5900b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10259",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "left-1-opacity": {
+          "type": "color",
+          "value": "#f20000b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10260",
+              "exportKey": "variables"
+            }
+          }
+        },
+        "ready-opacity": {
+          "type": "color",
+          "value": "#f20000b3",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "mode": "dark",
+              "collection": "Colors",
+              "scopes": [
+                "ALL_SCOPES"
+              ],
+              "variableId": "VariableID:2079:10261",
+              "exportKey": "variables"
+            }
+          }
+        }
+      }
+    }
+  },
+  "typography": {
+    "title": {
+      "title 1": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 28
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 600
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": -0.2
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 32
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      },
+      "title 2": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 24
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 700
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": -0.2
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 29
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      },
+      "title 3": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 22
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 700
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": -0.2
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 26
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      },
+      "title 5": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 20
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 400
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": -0.45
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 25
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      }
+    },
+    "body": {
+      "body 1": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 18
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 500
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": -0.2
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 23
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      },
+      "body 2": {
+        "medium": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 16
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 500
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 21
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        },
+        "regular": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 16
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 400
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 21
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        }
+      }
+    },
+    "label": {
+      "label2": {
+        "fontSize": {
+          "type": "dimension",
+          "value": 13
+        },
+        "textDecoration": {
+          "type": "string",
+          "value": "none"
+        },
+        "fontFamily": {
+          "type": "string",
+          "value": "Pretendard"
+        },
+        "fontWeight": {
+          "type": "number",
+          "value": 400
+        },
+        "fontStyle": {
+          "type": "string",
+          "value": "normal"
+        },
+        "fontStretch": {
+          "type": "string",
+          "value": "normal"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": 17
+        },
+        "paragraphIndent": {
+          "type": "dimension",
+          "value": 0
+        },
+        "paragraphSpacing": {
+          "type": "dimension",
+          "value": 0
+        },
+        "textCase": {
+          "type": "string",
+          "value": "none"
+        }
+      },
+      "label 1": {
+        "medium": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 14
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 500
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 19
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        },
+        "regular": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 14
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 400
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 19
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        },
+        "semibold": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 14
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 600
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 19
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        }
+      },
+      "label 3": {
+        "regular": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 12
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 400
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0.2
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 17
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        },
+        "semibold": {
+          "fontSize": {
+            "type": "dimension",
+            "value": 12
+          },
+          "textDecoration": {
+            "type": "string",
+            "value": "none"
+          },
+          "fontFamily": {
+            "type": "string",
+            "value": "Pretendard"
+          },
+          "fontWeight": {
+            "type": "number",
+            "value": 600
+          },
+          "fontStyle": {
+            "type": "string",
+            "value": "normal"
+          },
+          "fontStretch": {
+            "type": "string",
+            "value": "normal"
+          },
+          "letterSpacing": {
+            "type": "dimension",
+            "value": 0.2
+          },
+          "lineHeight": {
+            "type": "dimension",
+            "value": 17
+          },
+          "paragraphIndent": {
+            "type": "dimension",
+            "value": 0
+          },
+          "paragraphSpacing": {
+            "type": "dimension",
+            "value": 0
+          },
+          "textCase": {
+            "type": "string",
+            "value": "none"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
add color asset

<!--[#46] Assets에 컬러 등록 !!-->

## 📝 작업 내용
> Figma에서 지정한 컬러 파레트 이름과 동일하게 Xcode Assets에 등록했습니다. 
컬러값을 json으로 추출한뒤, python을 활용하여 xcode에 등록하고 이후에 약간의 수작업(?)으로 폴더 정리했습니다. 

[컬러 폴더 구조]
- Brand : 브랜드 컬러 파레트
- Bus : 버스 노선별 컬러
- Foundation : 기본 컬러 파레트(흰,검,회색,노랑,오렌지,레드)
- StopLeft : 남은 정거장 수에 따른 컬러(3,2,1정거장/ready)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 처음에 컬러 등록할 때, 이렇게 파일이 많은 것이 정상인가요...?ㅠ