### PR TITLE
[#54] 남은 정류장 수 업데이트에 따른 Live Activity Update 함수 작성

### DIFF
--- a/TMT/TMT/BusJourney/BusStopView.swift
+++ b/TMT/TMT/BusJourney/BusStopView.swift
@@ -15,7 +15,7 @@ struct Coordinate: Identifiable {
 
 struct BusStopView: View {
     @ObservedObject var locationManager: LocationManager
-    @ObservedObject var busStopSearchViewModel: BusStopSearchViewModel
+    @ObservedObject var busStopSearchViewModel: BusSearchViewModel
     @State private var coordinatesList: [Coordinate] = []
     @State private var journeyStops: [BusStopInfo] = []
     

--- a/TMT/TMT/BusSearch/BusSearchView.swift
+++ b/TMT/TMT/BusSearch/BusSearchView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct BusSearchView: View {
-    @StateObject private var busStopSearchViewModel = BusStopSearchViewModel()
+    @StateObject private var busStopSearchViewModel: BusSearchViewModel
+    @StateObject private var liveActivityManager: LiveActivityManager
     @StateObject var locationManager: LocationManager
     
     @State private var selectedStartStop: BusStopInfo?
@@ -17,9 +18,11 @@ struct BusSearchView: View {
     @State private var tag: Int? = nil
     
     init() {
-        let viewModel = BusStopSearchViewModel()
+        let viewModel = BusSearchViewModel()
+        let liveActivity = LiveActivityManager()
         _busStopSearchViewModel = StateObject(wrappedValue: viewModel)
-        _locationManager = StateObject(wrappedValue: LocationManager(viewModel: viewModel))
+        _liveActivityManager = StateObject(wrappedValue: liveActivity)
+        _locationManager = StateObject(wrappedValue: LocationManager(viewModel: viewModel, activityManager: liveActivity))
     }
     
     var body: some View {

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -82,8 +82,6 @@ final class BusSearchViewModel: ObservableObject {
                 self.journeyStops = filteredStops
             }
         }
-        
-        print(journeyStops)
     }
     
     private func searchBusStops(for busStopName: String) -> [BusStopInfo] {

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -8,13 +8,11 @@
 import Combine
 import ActivityKit
 
-@available(iOS 16.2, *)
 final class LiveActivityManager: ObservableObject {
-    @Published var num: Int = 0
     private var cancellable: Set<AnyCancellable> = Set()
     private var activity: Activity<BusJourneyAttributes>?
-    
-    func startLiveActivity(destinationInfo: BusStopInfo) {
+
+    func startLiveActivity(destinationInfo: BusStopInfo, remainingStops: Int) {
         if ActivityAuthorizationInfo().areActivitiesEnabled {
             // 실행 중인 라이브 액티비티가 있으면 종료됩니다.
             if let _ = activity {
@@ -26,7 +24,7 @@ final class LiveActivityManager: ObservableObject {
             
             let data = BusJourneyAttributes(stopNameKorean: stopNameKorean, stopNameRomanized: stropNameRomanized)
             
-            let initialState = BusJourneyAttributes.ContentState(remainingStopsCount: 0)
+            let initialState = BusJourneyAttributes.ContentState(remainingStopsCount: remainingStops)
             
             let content = ActivityContent(state: initialState, staleDate: nil)
             
@@ -49,28 +47,16 @@ final class LiveActivityManager: ObservableObject {
         }
     }
     
-    // TODO: 값에 변화생기면 라이브 액티비티 update 하는 코드입니다.
-    // 나중에 참고하려고 넣어놨어요. 값 업데이트되면 자동으로 다이나믹 아일랜드 확장형으로 보여줍니다.
-//    func timer() {
-//        Timer.publish(every: 10, on: .main, in: .default)
-//            .autoconnect()
-//            .sink { [self] _ in
-//                num += 1
-//                Task {
-//
-//                    print(num)
-//                    let activity = self.activity
-//                    let newState = BusJourneyAttributes.ContentState(remainingStopsCount: num)
-//                    // 애플워치에서 동작
-//                    let alertConfiguration = AlertConfiguration(
-//                        title: "timer update",
-//                        body: "현재숫자: \(num)",
-//                        sound: .default
-//                    )
-//                    await activity?.update(using: newState, alertConfiguration: alertConfiguration)
-//                }
-//            }
-//            .store(in: &cancellable)
-//    }
-
+    func updateLiveActivity(remainingStops: Int) async {
+        let contentState = BusJourneyAttributes.ContentState(remainingStopsCount: remainingStops)
+        
+        // TODO: 애플워치에 뜨는 알림. title, body 내용 수정해야 함. 애플 워치에 알림 안 띄우고 알림 보내는 방법은 없나 ??...
+        let alertConfig = AlertConfiguration(
+            title: "title",
+            body: "body",
+            sound: .default
+        )
+        
+        await activity?.update(ActivityContent<BusJourneyAttributes.ContentState>(state: contentState, staleDate: nil), alertConfiguration: alertConfig)
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 남은 정류장 수가 업데이트 되면 Live Activity를 Update하는 함수 작성했습니다.
- 현재 <ins>LocationManager에서 사용자 위치 업데이트 -> 남은 정류장 수 계산 -> 변화가 생기면 Live Activity Update 함수 호출</ins>하는 형태로 작성되어 있습니다.
- Live Activity가 업데이트 되면 **자동으로 다이나믹 아일랜드 화면이 확장**되어 보여집니다.

### 스크린샷
<img src="" width="300"/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 `LocationManager`에서 남은 정류장 수 계산 및 라이브 액티비티 업데이트가 모두 이뤄지도록 작성했는데, 매우 마음에 들지 않습니댜 .. 😂
  굉장히 복잡하게 작성되어 있는 느낌이고 책임 분리가 되어 있지 않습니다 ..
  일단 제가 수정하고 싶은 부분은,
  - `searchViewModel`에 작성되어 있는 `updateRemainingStops` 함수를 다른 뷰모델로 분리해야 합니다.
  - `LocationManager`에서는 위치만 관리할 수 있도록 수정할 예정입니다.
    - **AS-IS**: `LocationManager`에서 남은정류장 수 계산 및 라이브 액티비티 업데이트
    - **TO-BE**: `LocationManager`에서 사용자 위치만 받아와서, 뷰모델에서 남은정류장 수 계산 및 라이브 액티비티 업데이트 실행
- View 작업 먼저 진행한 다음, 로직 분리 작업하도록 할게요 ! (뷰 없이 하려니 생각이 잘 안 돼요 ...)