### PR TITLE
[#72] 사용자가 입력한 데이터와 start 이후 보여지는 정보 불일치 문제 해결

### DIFF
--- a/TMT/TMT/BusJourney/BusStopView.swift
+++ b/TMT/TMT/BusJourney/BusStopView.swift
@@ -40,7 +40,7 @@ struct BusStopView: View {
             if locationManager.isFirstLoad {
                 locationManager.findCurrentLocation()
             }
-            busStopSearchViewModel.searchBusStops(by: busStopSearchViewModel.journeyStops.first?.busNumber ?? "")
+            busStopSearchViewModel.searchBusStops(byNumber: busStopSearchViewModel.journeyStops.first?.busNumber ?? "")
             coordinatesList = getValidCoordinates()
         }
         // TODO: 실제로 줄어드는지 테스트 필요
@@ -69,7 +69,7 @@ struct BusStopView: View {
     
     /// 좌표의 옵셔널을 제거합니다.
     private func getValidCoordinates() -> [Coordinate] {
-        busStopSearchViewModel.filteredBusStops.compactMap { stop in
+        busStopSearchViewModel.filteredBusDataForNumber.compactMap { stop in
             guard let latitude = stop.latitude,
                   let longitude = stop.longitude else {
                 return nil

--- a/TMT/TMT/BusJourneyExtractor/ScannedJourneyInfoView.swift
+++ b/TMT/TMT/BusJourneyExtractor/ScannedJourneyInfoView.swift
@@ -21,8 +21,8 @@ struct ScannedJourneyInfoView: View {
     @StateObject private var liveActivityManager: LiveActivityManager
     @StateObject var locationManager: LocationManager
     
-    @State private var selectedStartStop: BusStopInfo?
-    @State private var selectedEndStop: BusStopInfo?
+    @State private var selectedStartStop: BusStop?
+    @State private var selectedEndStop: BusStop?
     
     @State private var tag: Int? = nil
     
@@ -77,7 +77,7 @@ struct ScannedJourneyInfoView: View {
                     }
                 
                 Button {
-                    busStopSearchViewModel.setJourneyStops(startStopString: startStop, endStopString: endStop)
+                    busStopSearchViewModel.setJourneyStops(busNumberString: busNumber, startStopString: startStop, endStopString: endStop)
                     
                     guard let endStop = busStopSearchViewModel.journeyStops.last else { return }
                     liveActivityManager.startLiveActivity(destinationInfo: endStop, remainingStops: locationManager.remainingStops)

--- a/TMT/TMT/BusSearch/BusSearchModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BusStopInfo: Codable, Identifiable {
+struct BusStop: Codable, Identifiable {
     var id = UUID()
     var busNumber: String? // 노선명 (버스번호)
     var busType: Int? // 버스 타입

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -12,7 +12,7 @@ final class LiveActivityManager: ObservableObject {
     private var cancellable: Set<AnyCancellable> = Set()
     private var activity: Activity<BusJourneyAttributes>?
 
-    func startLiveActivity(destinationInfo: BusStopInfo, remainingStops: Int) {
+    func startLiveActivity(destinationInfo: BusStop, remainingStops: Int) {
         if ActivityAuthorizationInfo().areActivitiesEnabled {
             // 실행 중인 라이브 액티비티가 있으면 종료됩니다.
             if let _ = activity {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- **사용자가 업로드한 스크린샷에서 읽은 데이터**와 **start 이후 맵뷰로 진입해서 확인하는 데이터**간 정보 불일치 문제 해결했습니다.
- 문제 원인은 다음과 같습니다.
  - 포항의 모든 시내 버스 데이터가 담긴 배열에서 출발/하차 정류장을 찾음.
  - 순서대로 찾기 때문에, 버스 번호와 관계없이 데이터 초반에 출발 정류장 이름이 동일한 데이터를 찾으면 끝남.
  - 그래서 <ins>207번 버스의 북구청</ins>을 찾는 상황이어도, 209번 데이터가 더 위에 위치하기 때문에 <ins>209번 버스의 북구청</ins>을 찾고 끝남.
 
- 해결 방법은 아래와 같습니다.
  - 모든 버스 데이터에서 <ins>사용자 버스 번호</ins>로 1차 필터링
  - 버스 번호로 필터링한 데이터에서 출발/하차 정류장 데이터 찾기
  - 출발 ~ 하차 정류장 배열 찾기


### 스크린샷
<img src="https://github.com/user-attachments/assets/fb41a459-3735-4cf1-8021-e24fd7e2c3b9" width="200"/> <img src="https://github.com/user-attachments/assets/0daecb08-cc25-4764-98ea-f5ebb8c38172" width="200"/> <img src="https://github.com/user-attachments/assets/161a9894-84d1-454b-9eaa-5b563ad87a5f" width="200"/> 
