### PR TITLE
[#79] 맵뷰에서 이전 페이지로 이동하면 Live Activity 종료

### DIFF
--- a/TMT/TMT/BusJourney/BusStopView.swift
+++ b/TMT/TMT/BusJourney/BusStopView.swift
@@ -43,7 +43,7 @@ struct BusStopView: View {
             coordinatesList = getValidCoordinates()
         }
         // TODO: 실제로 줄어드는지 테스트 필요
-        .onChange(of: busStopSearchViewModel.remainingStops) { searchResults in
+        .onChange(of: busStopSearchViewModel.remainingStops) { 
             passedStops = busStopSearchViewModel.journeyStops.count - busStopSearchViewModel.remainingStops
         }
     }

--- a/TMT/TMT/BusJourney/ThisStopView.swift
+++ b/TMT/TMT/BusJourney/ThisStopView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ThisStopView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @EnvironmentObject var activityManager: LiveActivityManager
     @State private var showingAlert = false
     
     var stopNameKorean: String
@@ -70,6 +71,7 @@ struct ThisStopView: View {
             }
             Button {
                 self.presentationMode.wrappedValue.dismiss()
+                activityManager.endLiveActivity()
             } label: {
                 Text("Exit")
                     .foregroundStyle(.blue)

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -44,6 +44,8 @@ final class LiveActivityManager: ObservableObject {
         
         Task {
             await activity?.end(ActivityContent(state: finalContent, staleDate: nil), dismissalPolicy: dismissalpolicy)
+            
+            activity = nil
         }
     }
     


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 사용자가 맵뷰에서 이전 페이지로 이동하면, 실행 중인 Live Activity를 종료하도록 했습니다.

