### PR TITLE
[#67] SearchViewModel에 작성되어 있던 승하차 정류장 설정 및 남은 정류장 수 계산 로직 분리

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		5BB6D2542CD372E900F6A487 /* ThisStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2532CD372E500F6A487 /* ThisStopView.swift */; };
 		5BB6D2582CD3DD1100F6A487 /* EndStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */; };
 		5BD0A4122CD67BD400AE88BF /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */; };
-		D81D9D3C2CE21CD1004F2024 /* BusJourneyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */; };
+		D81D9D3C2CE21CD1004F2024 /* JourneySettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9D3B2CE21CD1004F2024 /* JourneySettingViewModel.swift */; };
 		D826488F2CD35550000A448D /* ButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826488E2CD35550000A448D /* ButtonComponent.swift */; };
 		D82D29A52CD3AC8B0083BB59 /* OnboardingStepEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D29A42CD3AC8B0083BB59 /* OnboardingStepEnum.swift */; };
 		D844BCBD2CC120010059E31F /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D844BCBC2CC120010059E31F /* WidgetKit.framework */; };
@@ -79,7 +79,7 @@
 		5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndStopView.swift; sourceTree = "<group>"; };
 		5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
 		D803DE332CD8A80C00C36D17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusJourneyViewModel.swift; sourceTree = "<group>"; };
+		D81D9D3B2CE21CD1004F2024 /* JourneySettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneySettingViewModel.swift; sourceTree = "<group>"; };
 		D826488E2CD35550000A448D /* ButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponent.swift; sourceTree = "<group>"; };
 		D82D29A42CD3AC8B0083BB59 /* OnboardingStepEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStepEnum.swift; sourceTree = "<group>"; };
 		D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TMTWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,7 +159,7 @@
 				5B6DA5B72CBE551400613ACB /* BusStopView.swift */,
 				5B4F87332CC973F3000329C2 /* BusStopViewWrapper.swift */,
 				5B0C4AF32CD52E0F00031147 /* StopStatusEnum.swift */,
-				D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */,
+				D81D9D3B2CE21CD1004F2024 /* JourneySettingViewModel.swift */,
 			);
 			path = BusJourney;
 			sourceTree = "<group>";
@@ -397,7 +397,7 @@
 				5B83D51E2CD7D81F00633B3C /* NotUploadedView.swift in Sources */,
 				D858729C2CD4A15F001CC467 /* OnboardingStepView.swift in Sources */,
 				D88F3AF22CD34DD200C0B657 /* OnboardingView.swift in Sources */,
-				D81D9D3C2CE21CD1004F2024 /* BusJourneyViewModel.swift in Sources */,
+				D81D9D3C2CE21CD1004F2024 /* JourneySettingViewModel.swift in Sources */,
 				5B2D9A182CCA36EA001FF6CC /* BusJourneyExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5BB6D2542CD372E900F6A487 /* ThisStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2532CD372E500F6A487 /* ThisStopView.swift */; };
 		5BB6D2582CD3DD1100F6A487 /* EndStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */; };
 		5BD0A4122CD67BD400AE88BF /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */; };
+		D81D9D3C2CE21CD1004F2024 /* BusJourneyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */; };
 		D826488F2CD35550000A448D /* ButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826488E2CD35550000A448D /* ButtonComponent.swift */; };
 		D82D29A52CD3AC8B0083BB59 /* OnboardingStepEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D29A42CD3AC8B0083BB59 /* OnboardingStepEnum.swift */; };
 		D844BCBD2CC120010059E31F /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D844BCBC2CC120010059E31F /* WidgetKit.framework */; };
@@ -78,6 +79,7 @@
 		5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndStopView.swift; sourceTree = "<group>"; };
 		5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
 		D803DE332CD8A80C00C36D17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusJourneyViewModel.swift; sourceTree = "<group>"; };
 		D826488E2CD35550000A448D /* ButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponent.swift; sourceTree = "<group>"; };
 		D82D29A42CD3AC8B0083BB59 /* OnboardingStepEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStepEnum.swift; sourceTree = "<group>"; };
 		D844BCBA2CC120010059E31F /* TMTWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TMTWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -152,11 +154,12 @@
 		5BCE456F2CC389FE00CF38CE /* BusJourney */ = {
 			isa = PBXGroup;
 			children = (
-				5B0C4AF32CD52E0F00031147 /* StopStatusEnum.swift */,
 				5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */,
 				5BB6D2532CD372E500F6A487 /* ThisStopView.swift */,
-				5B4F87332CC973F3000329C2 /* BusStopViewWrapper.swift */,
 				5B6DA5B72CBE551400613ACB /* BusStopView.swift */,
+				5B4F87332CC973F3000329C2 /* BusStopViewWrapper.swift */,
+				5B0C4AF32CD52E0F00031147 /* StopStatusEnum.swift */,
+				D81D9D3B2CE21CD1004F2024 /* BusJourneyViewModel.swift */,
 			);
 			path = BusJourney;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				5B83D51E2CD7D81F00633B3C /* NotUploadedView.swift in Sources */,
 				D858729C2CD4A15F001CC467 /* OnboardingStepView.swift in Sources */,
 				D88F3AF22CD34DD200C0B657 /* OnboardingView.swift in Sources */,
+				D81D9D3C2CE21CD1004F2024 /* BusJourneyViewModel.swift in Sources */,
 				5B2D9A182CCA36EA001FF6CC /* BusJourneyExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TMT/TMT/BusJourney/BusJourneyViewModel.swift
+++ b/TMT/TMT/BusJourney/BusJourneyViewModel.swift
@@ -1,0 +1,93 @@
+//
+//  BusJourneyViewModel.swift
+//  TMT
+//
+//  Created by 김유빈 on 11/11/24.
+//
+
+import Foundation
+import MapKit
+
+final class BusJourneyViewModel: ObservableObject {
+    @Published var journeyStops: [BusStop] = []
+    
+    private var startStop: BusStop?
+    private var endStop: BusStop?
+    
+    private let searchModel: BusSearchViewModel
+    
+    init(searchModel: BusSearchViewModel) {
+        self.searchModel = searchModel
+    }
+    
+    // MARK: 출발 및 하차 정류장 설정
+    func setJourneyStops(busNumberString: String, startStopString: String, endStopString: String) {
+        searchModel.searchBusStops(byNumber: busNumberString)
+        
+        let startCandidates = searchModel.searchBusStops(byName: startStopString)
+        let endCandidates = searchModel.searchBusStops(byName: endStopString)
+
+        findJourneyStopsSequence(from: startCandidates, to: endCandidates)
+    }
+
+    // MARK: 출뱔 정류장부터 하차 정류장까지 배열 찾기
+    func findJourneyStopsSequence(from startCandidates: [BusStop], to endCandidates: [BusStop]) {
+        if let validStops = findValidStartAndEndStops(from: startCandidates, to: endCandidates) {
+            self.startStop = validStops.startStop
+            self.endStop = validStops.endStop
+            
+            if let startOrder = validStops.startStop.stopOrder, let endOrder = validStops.endStop.stopOrder {
+                let filteredStops = searchModel.allBusData.filter {
+                    guard let order = $0.stopOrder else { return false }
+                    return $0.busNumber == startStop?.busNumber && order >= startOrder && order <= endOrder
+                }
+                self.journeyStops = filteredStops
+            }
+        }
+    }
+    
+    private func findValidStartAndEndStops(from startCandidates: [BusStop], to endCandidates: [BusStop]) -> (startStop: BusStop, endStop: BusStop)? {
+        let startOrders = startCandidates.compactMap { $0.stopOrder }
+        let endOrders = endCandidates.compactMap { $0.stopOrder }
+        guard let startMin = startOrders.min(), let endMin = endOrders.min(),
+              let startMax = startOrders.max(), let endMax = endOrders.max() else { return nil }
+        
+        if startMin < endMin {
+            if let startInfo = startCandidates.first(where: { $0.stopOrder == startMin }),
+               let endInfo = endCandidates.first(where: { $0.stopOrder == endMin }) {
+                return (startInfo, endInfo)
+            }
+        } else {
+            if let startInfo = startCandidates.first(where: { $0.stopOrder == startMax }),
+               let endInfo = endCandidates.first(where: { $0.stopOrder == endMax }) {
+                return (startInfo, endInfo)
+            }
+        }
+        return nil
+    }
+    
+    /// 실시간으로 남은 정류장 수 업데이트
+    func updateRemainingStops(currentLocation: CLLocationCoordinate2D) -> Int {
+        guard !journeyStops.isEmpty else {
+            print("정류장 설정 plz ..")
+            return 0
+        }
+        
+        var passedStops = 0
+        
+        for (index, stop) in journeyStops.enumerated() {
+            guard let stopLatitude = stop.latitude, let stopLongitude = stop.longitude else { continue }
+            
+            let stopLocation = CLLocation(latitude: stopLatitude, longitude: stopLongitude)
+            let userLocation = CLLocation(latitude: currentLocation.latitude, longitude: currentLocation.longitude)
+            
+            if userLocation.distance(from: stopLocation) < 50.0 {
+                passedStops = index
+                break
+            }
+        }
+                
+        return max(0, journeyStops.count - passedStops - 1)
+    }
+
+}

--- a/TMT/TMT/BusJourney/BusStopView.swift
+++ b/TMT/TMT/BusJourney/BusStopView.swift
@@ -15,7 +15,8 @@ struct Coordinate: Identifiable {
 
 struct BusStopView: View {
     @EnvironmentObject var locationManager: LocationManager
-    @EnvironmentObject var busStopSearchViewModel: BusSearchViewModel
+    @EnvironmentObject var searchModel: BusSearchViewModel
+    @EnvironmentObject var journeyModel: BusJourneyViewModel
     @State private var coordinatesList: [Coordinate] = []
     @State private var passedStops: Int = 0
     
@@ -23,28 +24,34 @@ struct BusStopView: View {
         ZStack {
             busStopViewWrapper
                 .edgesIgnoringSafeArea(.vertical)
+            
             VStack {
-                ThisStopView(stopNameKorean: busStopSearchViewModel.journeyStops[passedStops].stopNameKorean ?? "", stopNameNaver: busStopSearchViewModel.journeyStops[passedStops].stopNameNaver ?? "", stopNameRomanized: busStopSearchViewModel.journeyStops[passedStops].stopNameRomanized ?? "")
+                ThisStopView(stopNameKorean: journeyModel.journeyStops[passedStops].stopNameKorean ?? "", stopNameNaver: journeyModel.journeyStops[passedStops].stopNameNaver ?? "", stopNameRomanized: journeyModel.journeyStops[passedStops].stopNameRomanized ?? "")
+                
                 HStack {
                     Spacer()
+                    
                     controlsView
                         .padding(.trailing, 15.48)
                         .padding(.top, 23.91)
                 }
+                
                 Spacer()
-                    EndStopView(endStop: busStopSearchViewModel.journeyStops.last?.stopNameNaver ?? "", remainingStops: busStopSearchViewModel.remainingStops)
+                
+                EndStopView(endStop: journeyModel.journeyStops.last?.stopNameNaver ?? "", remainingStops: locationManager.remainingStops)
             }
         }
         .onAppear {
             if locationManager.isFirstLoad {
                 locationManager.findCurrentLocation()
             }
-            busStopSearchViewModel.searchBusStops(byNumber: busStopSearchViewModel.journeyStops.first?.busNumber ?? "")
+            
+            searchModel.searchBusStops(byNumber: journeyModel.journeyStops.first?.busNumber ?? "")
             coordinatesList = getValidCoordinates()
         }
         // TODO: 실제로 줄어드는지 테스트 필요
-        .onChange(of: busStopSearchViewModel.remainingStops) { 
-            passedStops = busStopSearchViewModel.journeyStops.count - busStopSearchViewModel.remainingStops
+        .onChange(of: locationManager.remainingStops) {
+            passedStops = journeyModel.journeyStops.count - locationManager.remainingStops
         }
     }
     
@@ -60,6 +67,7 @@ struct BusStopView: View {
                 Circle()
                     .frame(width: 44, height: 44)
                     .tint(Color.Basic.grey70)
+                
                 Image(systemName: "location.fill")
                     .tint(Color.Basic.yellow500)
             }
@@ -68,7 +76,7 @@ struct BusStopView: View {
     
     /// 좌표의 옵셔널을 제거합니다.
     private func getValidCoordinates() -> [Coordinate] {
-        busStopSearchViewModel.filteredBusDataForNumber.compactMap { stop in
+        searchModel.filteredBusDataForNumber.compactMap { stop in
             guard let latitude = stop.latitude,
                   let longitude = stop.longitude else {
                 return nil

--- a/TMT/TMT/BusJourney/BusStopView.swift
+++ b/TMT/TMT/BusJourney/BusStopView.swift
@@ -16,7 +16,7 @@ struct Coordinate: Identifiable {
 struct BusStopView: View {
     @EnvironmentObject var locationManager: LocationManager
     @EnvironmentObject var searchModel: BusSearchViewModel
-    @EnvironmentObject var journeyModel: BusJourneyViewModel
+    @EnvironmentObject var journeyModel: JourneySettingViewModel
     @State private var coordinatesList: [Coordinate] = []
     @State private var passedStops: Int = 0
     

--- a/TMT/TMT/BusJourney/JourneySettingViewModel.swift
+++ b/TMT/TMT/BusJourney/JourneySettingViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  BusJourneyViewModel.swift
+//  JourneySettingViewModel.swift
 //  TMT
 //
 //  Created by 김유빈 on 11/11/24.
@@ -8,7 +8,7 @@
 import Foundation
 import MapKit
 
-final class BusJourneyViewModel: ObservableObject {
+final class JourneySettingViewModel: ObservableObject {
     @Published var journeyStops: [BusStop] = []
     
     private var startStop: BusStop?

--- a/TMT/TMT/BusJourneyExtractor/ScannedJourneyInfoView.swift
+++ b/TMT/TMT/BusJourneyExtractor/ScannedJourneyInfoView.swift
@@ -18,7 +18,7 @@ struct ScannedJourneyInfoView: View {
     @Binding var isLoading: Bool
     
     @StateObject private var searchModel: BusSearchViewModel
-    @StateObject private var journeyModel: BusJourneyViewModel
+    @StateObject private var journeyModel: JourneySettingViewModel
     @StateObject private var activityManager: LiveActivityManager
     @StateObject var locationManager: LocationManager
     
@@ -29,7 +29,7 @@ struct ScannedJourneyInfoView: View {
     
     init(scannedJourneyInfo: Binding<String>, selectedImage: Binding<UIImage?>, isLoading: Binding<Bool>) {
         let searchModel = BusSearchViewModel()
-        let journeyModel = BusJourneyViewModel(searchModel: searchModel)
+        let journeyModel = JourneySettingViewModel(searchModel: searchModel)
         let activityManager = LiveActivityManager()
         _searchModel = StateObject(wrappedValue: searchModel)
         _journeyModel = StateObject(wrappedValue: journeyModel)

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import MapKit
 
 final class BusSearchViewModel: ObservableObject {
     @Published var allBusData: [BusStop] = []

--- a/TMT/TMT/BusSearch/BusSearchViewModel.swift
+++ b/TMT/TMT/BusSearch/BusSearchViewModel.swift
@@ -11,11 +11,6 @@ import MapKit
 final class BusSearchViewModel: ObservableObject {
     @Published var allBusData: [BusStop] = []
     @Published var filteredBusDataForNumber: [BusStop] = []
-    @Published var remainingStops: Int = 0
-    @Published var journeyStops: [BusStop] = []
-    
-    private var startStop: BusStop?
-    private var endStop: BusStop?
     
     init() {
         loadCSV()
@@ -56,16 +51,6 @@ final class BusSearchViewModel: ObservableObject {
         }
     }
     
-    // MARK: 출발 및 하차 정류장 설정
-    func setJourneyStops(busNumberString: String, startStopString: String, endStopString: String) {
-        searchBusStops(byNumber: busNumberString)
-        
-        let startCandidates = searchBusStops(byName: startStopString)
-        let endCandidates = searchBusStops(byName: endStopString)
-
-        findJourneyStopsSequence(from: startCandidates, to: endCandidates)
-    }
-    
     // MARK: 버스 데이터 검색 (버스 번호, 정류장 이름)
     func searchBusStops(byNumber number: String) {
         filteredBusDataForNumber = allBusData.filter { busStop in
@@ -76,71 +61,9 @@ final class BusSearchViewModel: ObservableObject {
         }
     }
 
-    private func searchBusStops(byName name: String) -> [BusStop] {
+    func searchBusStops(byName name: String) -> [BusStop] {
         return filteredBusDataForNumber.filter {
             name.contains($0.stopNameNaver ?? "") || name.contains($0.stopNameKorean ?? "")
         }
-    }
-    
-    // MARK: 출뱔 정류장부터 하차 정류장까지 배열 찾기
-    func findJourneyStopsSequence(from startCandidates: [BusStop], to endCandidates: [BusStop]) {
-        if let validStops = findValidStartAndEndStops(from: startCandidates, to: endCandidates) {
-            self.startStop = validStops.startStop
-            self.endStop = validStops.endStop
-            
-            if let startOrder = validStops.startStop.stopOrder, let endOrder = validStops.endStop.stopOrder {
-                let filteredStops = allBusData.filter {
-                    guard let order = $0.stopOrder else { return false }
-                    return $0.busNumber == startStop?.busNumber && order >= startOrder && order <= endOrder
-                }
-                self.journeyStops = filteredStops
-            }
-        }
-    }
-    
-    private func findValidStartAndEndStops(from startCandidates: [BusStop], to endCandidates: [BusStop]) -> (startStop: BusStop, endStop: BusStop)? {
-        let startOrders = startCandidates.compactMap { $0.stopOrder }
-        let endOrders = endCandidates.compactMap { $0.stopOrder }
-        guard let startMin = startOrders.min(), let endMin = endOrders.min(),
-              let startMax = startOrders.max(), let endMax = endOrders.max() else { return nil }
-        
-        if startMin < endMin {
-            if let startInfo = startCandidates.first(where: { $0.stopOrder == startMin }),
-               let endInfo = endCandidates.first(where: { $0.stopOrder == endMin }) {
-                return (startInfo, endInfo)
-            }
-        } else {
-            if let startInfo = startCandidates.first(where: { $0.stopOrder == startMax }),
-               let endInfo = endCandidates.first(where: { $0.stopOrder == endMax }) {
-                return (startInfo, endInfo)
-            }
-        }
-        return nil
-    }
-    
-    /// 실시간으로 남은 정류장 수 업데이트
-    func updateRemainingStops(currentLocation: CLLocationCoordinate2D) -> Int {
-        guard !journeyStops.isEmpty else {
-            print("정류장 설정 plz ..")
-            return 0
-        }
-        
-        var passedStops = 0
-        
-        for (index, stop) in journeyStops.enumerated() {
-            guard let stopLatitude = stop.latitude, let stopLongitude = stop.longitude else { continue }
-            
-            let stopLocation = CLLocation(latitude: stopLatitude, longitude: stopLongitude)
-            let userLocation = CLLocation(latitude: currentLocation.latitude, longitude: currentLocation.longitude)
-            
-            if userLocation.distance(from: stopLocation) < 50.0 {
-                passedStops = index
-                break
-            }
-        }
-        
-        self.remainingStops = max(0, journeyStops.count - passedStops - 1)
-        
-        return self.remainingStops
     }
 }

--- a/TMT/TMT/Utils/LocationManager.swift
+++ b/TMT/TMT/Utils/LocationManager.swift
@@ -27,12 +27,12 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     }
     
     private let locationManager = CLLocationManager()
-    private weak var viewModel: BusSearchViewModel?
     private weak var activityManager: LiveActivityManager?
+    private weak var journeyModel: BusJourneyViewModel?
     
-    init(viewModel: BusSearchViewModel, activityManager: LiveActivityManager) {
-        self.viewModel = viewModel
+    init(activityManager: LiveActivityManager, journeyModel: BusJourneyViewModel) {
         self.activityManager = activityManager
+        self.journeyModel = journeyModel
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
@@ -67,7 +67,7 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
                 }
                 self.userLocation = location.coordinate
                 
-                self.remainingStops = self.viewModel?.updateRemainingStops(currentLocation: self.userLocation) ?? 0
+                self.remainingStops = self.journeyModel?.updateRemainingStops(currentLocation: self.userLocation) ?? 0
             }
         }
     }

--- a/TMT/TMT/Utils/LocationManager.swift
+++ b/TMT/TMT/Utils/LocationManager.swift
@@ -28,9 +28,9 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     
     private let locationManager = CLLocationManager()
     private weak var activityManager: LiveActivityManager?
-    private weak var journeyModel: BusJourneyViewModel?
+    private weak var journeyModel: JourneySettingViewModel?
     
-    init(activityManager: LiveActivityManager, journeyModel: BusJourneyViewModel) {
+    init(activityManager: LiveActivityManager, journeyModel: JourneySettingViewModel) {
         self.activityManager = activityManager
         self.journeyModel = journeyModel
         super.init()


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 모델을 **역할**에 따라 분리했습니다.
  - 기존 `BusSearchViewModel`은 CSV 파일 읽기 / 버스 검색 / 승하차 정류장 설정 / 남은 정류장 수 계산 등 여러 기능을 포함하고 있어, 이름과 역할이 맞지 않는 부분이 있었습니다.
 
  - 이에 따라 `BusSearchViewModel`에서는 <ins>검색 관련 작업</ins>만 수행하도록 하고, 불필요한 로직들을 분리했습니다.
  - <ins>승하차 정류장 설정 및 남은 정류장 수 계산</ins> 로직은 `BusJourneyViewModel`로 이동하여, 각 모델의 역할을 명확히 했습니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- BusJourneyViewModel 이름을 보고 어떤 역할을 하는지 이해가 잘 되시나용 ..~?
