### PR TITLE
[#94] 남은 정류장 수가 감소했다가 다시 증가하는 이슈 해결

### DIFF
--- a/TMT/TMT/Map/Models/JourneySettingModel.swift
+++ b/TMT/TMT/Map/Models/JourneySettingModel.swift
@@ -14,6 +14,8 @@ final class JourneySettingModel: ObservableObject {
     private var startStop: BusStop?
     private var endStop: BusStop?
     
+    private var lastPassedStopIndex: Int = -1
+    
     private let searchModel: BusSearchModel
     
     init(searchModel: BusSearchModel) {
@@ -26,12 +28,12 @@ final class JourneySettingModel: ObservableObject {
         
         let startCandidates = searchModel.searchBusStops(byName: startStopString)
         let endCandidates = searchModel.searchBusStops(byName: endStopString)
-
+        
         findJourneyStopsSequence(from: startCandidates, to: endCandidates)
     }
-
-    // MARK: 출뱔 정류장부터 하차 정류장까지 배열 찾기
-    func findJourneyStopsSequence(from startCandidates: [BusStop], to endCandidates: [BusStop]) {
+    
+    // MARK: 출발 정류장부터 하차 정류장까지 배열 찾기
+    private func findJourneyStopsSequence(from startCandidates: [BusStop], to endCandidates: [BusStop]) {
         if let validStops = findValidStartAndEndStops(from: startCandidates, to: endCandidates) {
             self.startStop = validStops.startStop
             self.endStop = validStops.endStop
@@ -73,21 +75,18 @@ final class JourneySettingModel: ObservableObject {
             return 0
         }
         
-        var passedStops = 0
-        
         for (index, stop) in journeyStops.enumerated() {
-            guard let stopLatitude = stop.latitude, let stopLongitude = stop.longitude else { continue }
+            guard index > lastPassedStopIndex, let stopLatitude = stop.latitude, let stopLongitude = stop.longitude else { continue }
             
             let stopLocation = CLLocation(latitude: stopLatitude, longitude: stopLongitude)
             let userLocation = CLLocation(latitude: currentLocation.latitude, longitude: currentLocation.longitude)
             
             if userLocation.distance(from: stopLocation) < 50.0 {
-                passedStops = index
+                lastPassedStopIndex = index
                 break
             }
         }
-                
-        return max(0, journeyStops.count - passedStops - 1)
+        
+        return max(0, journeyStops.count - lastPassedStopIndex - 1)
     }
-
 }


### PR DESCRIPTION
<!--
    [#이슈번호] Title
ex) [#1] PR Templete 생성
-->

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 지나친 정류장을 알기 위해 `lastPassedStopIndex` 변수 추가

- 이미 지나친 정류장은 계산에서 제외하도록 로직 수정
- 사용자가 현재 위치에서 가까운 정류장 도달 시 `lastPassedStopIndex` 업데이트



## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- **사용자가 버스 탑승 후 몇 정거장 지나친 다음에 start한 경우**는 아직 해결하지 못 했습니다 ...
  - '현재 로직으로도 이 상황을 커버할 수 있나?' 라는 생각이 살짝 드는데,
    머리가 굳었는지 잘 모르게써요.. 주말동안 열심히 생각해오겠습니다 🥲

