### PR TITLE
[#114] 🚨HOTFIX🚨삭제된 파일 복구 및 에러 수정

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		5BCC7CC82CF5BEDB005986BF /* BusStopDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC7CC72CF5BED4005986BF /* BusStopDetailView.swift */; };
 		5BE1BF082CF867590082648D /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF072CF867550082648D /* NotificationManager.swift */; };
 		5BE1BF5B2CF8C53E0082648D /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF5A2CF8C53A0082648D /* ScannedJourneyInfoView.swift */; };
+		5BE1BF5D2CF8C6150082648D /* ScannedJourneyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF5C2CF8C6100082648D /* ScannedJourneyInfo.swift */; };
+		5BE1BF5F2CF8C70F0082648D /* EndStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF5E2CF8C70C0082648D /* EndStopView.swift */; };
 		5BF33BF42CE70E2E006F17EC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86739702CA933CE00FFE8ED /* Assets.xcassets */; };
 		5BF33BF52CE70E37006F17EC /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9E9B2CE47F12004F2024 /* Color.swift */; };
 		D801A1BA2CF2213C00AD0D64 /* BusDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801A1B92CF2213C00AD0D64 /* BusDataMock.swift */; };
@@ -93,7 +95,6 @@
 		5B347FCF2CF4F71F00A1E852 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5B4F87332CC973F3000329C2 /* MapViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewWrapper.swift; sourceTree = "<group>"; };
 		5B50F1862CE5D14F00E2EC41 /* ImageHandlerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHandlerModel.swift; sourceTree = "<group>"; };
-		5B50F1882CE64EB500E2EC41 /* ScannedJourneyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfo.swift; sourceTree = "<group>"; };
 		5B64AF942CCF82270083CA23 /* BusInfoEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusInfoEnum.swift; sourceTree = "<group>"; };
 		5B6DA5B72CBE551400613ACB /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
@@ -103,10 +104,11 @@
 		5BA06D492CF38E1F00834BBD /* TappedStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappedStopView.swift; sourceTree = "<group>"; };
 		5BA06D4B2CF3A61C00834BBD /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
 		5BA3A5842CE12D8900C2DEA0 /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
-		5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndStopView.swift; sourceTree = "<group>"; };
 		5BCC7CC72CF5BED4005986BF /* BusStopDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusStopDetailView.swift; sourceTree = "<group>"; };
 		5BE1BF072CF867550082648D /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		5BE1BF5A2CF8C53A0082648D /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
+		5BE1BF5C2CF8C6100082648D /* ScannedJourneyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfo.swift; sourceTree = "<group>"; };
+		5BE1BF5E2CF8C70C0082648D /* EndStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndStopView.swift; sourceTree = "<group>"; };
 		D801A1B92CF2213C00AD0D64 /* BusDataMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusDataMock.swift; sourceTree = "<group>"; };
 		D803DE332CD8A80C00C36D17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D81D9D3B2CE21CD1004F2024 /* JourneySettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneySettingModel.swift; sourceTree = "<group>"; };
@@ -208,7 +210,7 @@
 		D801A1BB2CF229CA00AD0D64 /* DestinationCard */ = {
 			isa = PBXGroup;
 			children = (
-				5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */,
+				5BE1BF5E2CF8C70C0082648D /* EndStopView.swift */,
 				5BCC7CC72CF5BED4005986BF /* BusStopDetailView.swift */,
 			);
 			path = DestinationCard;
@@ -263,7 +265,7 @@
 		D81D9E952CE47E06004F2024 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				5B50F1882CE64EB500E2EC41 /* ScannedJourneyInfo.swift */,
+				5BE1BF5C2CF8C6100082648D /* ScannedJourneyInfo.swift */,
 				5B50F1862CE5D14F00E2EC41 /* ImageHandlerModel.swift */,
 				5B64AF942CCF82270083CA23 /* BusInfoEnum.swift */,
 				5B2D9A112CCA1521001FF6CC /* OCRStarterManager.swift */,
@@ -571,6 +573,7 @@
 				D826488F2CD35550000A448D /* ButtonComponent.swift in Sources */,
 				D867396D2CA933CD00FFE8ED /* TMTApp.swift in Sources */,
 				5B4F87342CC973F4000329C2 /* MapViewWrapper.swift in Sources */,
+				5BE1BF5F2CF8C70F0082648D /* EndStopView.swift in Sources */,
 				D8D377EB2CBE95CA0043D103 /* BusSearchModel.swift in Sources */,
 				5BE1BF082CF867590082648D /* NotificationManager.swift in Sources */,
 				D801A1BA2CF2213C00AD0D64 /* BusDataMock.swift in Sources */,
@@ -584,6 +587,7 @@
 				D844BCDA2CC147390059E31F /* LiveActivityManager.swift in Sources */,
 				5B83D51E2CD7D81F00633B3C /* NotUploadedView.swift in Sources */,
 				D858729C2CD4A15F001CC467 /* OnboardingStepView.swift in Sources */,
+				5BE1BF5D2CF8C6150082648D /* ScannedJourneyInfo.swift in Sources */,
 				D88F3AF22CD34DD200C0B657 /* InformationModalView.swift in Sources */,
 				D8E054DE2CF1AF89006B1879 /* View.swift in Sources */,
 				D81D9D3C2CE21CD1004F2024 /* JourneySettingModel.swift in Sources */,

--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		5B347FD02CF4F72400A1E852 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B347FCF2CF4F71F00A1E852 /* AppDelegate.swift */; };
 		5B4F87342CC973F4000329C2 /* MapViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F87332CC973F3000329C2 /* MapViewWrapper.swift */; };
 		5B50F1872CE5D19100E2EC41 /* ImageHandlerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B50F1862CE5D14F00E2EC41 /* ImageHandlerModel.swift */; };
-		5B50F1892CE64EBE00E2EC41 /* ScannedJourneyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B50F1882CE64EB500E2EC41 /* ScannedJourneyInfo.swift */; };
 		5B64AF952CCF823D0083CA23 /* BusInfoEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B64AF942CCF82270083CA23 /* BusInfoEnum.swift */; };
 		5B6DA5B82CBE551400613ACB /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B72CBE551400613ACB /* MapView.swift */; };
 		5B6DA5BA2CBE6F8C00613ACB /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6DA5B92CBE6F8700613ACB /* LocationManager.swift */; };
@@ -25,10 +24,9 @@
 		5BA06D4A2CF38E5400834BBD /* TappedStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA06D492CF38E1F00834BBD /* TappedStopView.swift */; };
 		5BA06D4C2CF3A63000834BBD /* PopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA06D4B2CF3A61C00834BBD /* PopoverView.swift */; };
 		5BA3A5852CE12D8900C2DEA0 /* BusStopData.csv in Resources */ = {isa = PBXBuildFile; fileRef = 5BA3A5842CE12D8900C2DEA0 /* BusStopData.csv */; };
-		5BE1BF082CF867590082648D /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF072CF867550082648D /* NotificationManager.swift */; };
-		5BB6D2582CD3DD1100F6A487 /* EndStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */; };
 		5BCC7CC82CF5BEDB005986BF /* BusStopDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC7CC72CF5BED4005986BF /* BusStopDetailView.swift */; };
-		5BD0A4122CD67BD400AE88BF /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */; };
+		5BE1BF082CF867590082648D /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF072CF867550082648D /* NotificationManager.swift */; };
+		5BE1BF5B2CF8C53E0082648D /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1BF5A2CF8C53A0082648D /* ScannedJourneyInfoView.swift */; };
 		5BF33BF42CE70E2E006F17EC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86739702CA933CE00FFE8ED /* Assets.xcassets */; };
 		5BF33BF52CE70E37006F17EC /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9E9B2CE47F12004F2024 /* Color.swift */; };
 		D801A1BA2CF2213C00AD0D64 /* BusDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801A1B92CF2213C00AD0D64 /* BusDataMock.swift */; };
@@ -105,10 +103,10 @@
 		5BA06D492CF38E1F00834BBD /* TappedStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappedStopView.swift; sourceTree = "<group>"; };
 		5BA06D4B2CF3A61C00834BBD /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
 		5BA3A5842CE12D8900C2DEA0 /* BusStopData.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = BusStopData.csv; sourceTree = "<group>"; };
-		5BE1BF072CF867550082648D /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndStopView.swift; sourceTree = "<group>"; };
 		5BCC7CC72CF5BED4005986BF /* BusStopDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusStopDetailView.swift; sourceTree = "<group>"; };
-		5BD0A4112CD67BC300AE88BF /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
+		5BE1BF072CF867550082648D /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		5BE1BF5A2CF8C53A0082648D /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
 		D801A1B92CF2213C00AD0D64 /* BusDataMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusDataMock.swift; sourceTree = "<group>"; };
 		D803DE332CD8A80C00C36D17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D81D9D3B2CE21CD1004F2024 /* JourneySettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneySettingModel.swift; sourceTree = "<group>"; };
@@ -255,8 +253,8 @@
 		D81D9E942CE47E01004F2024 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5BE1BF5A2CF8C53A0082648D /* ScannedJourneyInfoView.swift */,
 				5B83D51D2CD7D80900633B3C /* NotUploadedView.swift */,
-				5BCC7CEF2CF5FF93005986BF /* ScannedJourneyInfoView.swift */,
 				5B04FC502CD9BBFD00163877 /* UploadedPhotoView.swift */,
 			);
 			path = Views;
@@ -286,7 +284,6 @@
 		D81D9E972CE47E82004F2024 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				5BE1BF052CF864C30082648D /* BusStopDetailView.swift */,
 				5B347FCD2CF49DBC00A1E852 /* BusStopArrivalView.swift */,
 				5BA06D4B2CF3A61C00834BBD /* PopoverView.swift */,
 				5BA06D492CF38E1F00834BBD /* TappedStopView.swift */,
@@ -546,7 +543,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8E7E7122CF60FD300EAD54F /* StopStatusEnum.swift in Sources */,
-				5BE1BF092CF867590082648D /* NotificationManager.swift in Sources */,
 				D8E054DD2CF1AF89006B1879 /* View.swift in Sources */,
 				5BF33BF52CE70E37006F17EC /* Color.swift in Sources */,
 			);
@@ -558,13 +554,11 @@
 			files = (
 				5BCC7CC82CF5BEDB005986BF /* BusStopDetailView.swift in Sources */,
 				D83277652CEC67CE005E00CF /* LottieView.swift in Sources */,
-				5BCC7D162CF601E1005986BF /* EndStopView.swift in Sources */,
 				D8D377E92CBE95C30043D103 /* BusSearchItem.swift in Sources */,
-				5BE1BF062CF864CB0082648D /* BusStopDetailView.swift in Sources */,
 				5B04FC512CD9BC0400163877 /* UploadedPhotoView.swift in Sources */,
 				5B2D9A122CCA1553001FF6CC /* OCRStarterManager.swift in Sources */,
-				5BCC7CF02CF5FF93005986BF /* ScannedJourneyInfoView.swift in Sources */,
 				5B2D9A122CCA1553001FF6CC /* OCRStarterManager.swift in Sources */,
+				5BE1BF5B2CF8C53E0082648D /* ScannedJourneyInfoView.swift in Sources */,
 				5B50F1872CE5D19100E2EC41 /* ImageHandlerModel.swift in Sources */,
 				5B85B1C22CD91CC000469D03 /* HomeView.swift in Sources */,
 				5B0C4AF42CD52E1800031147 /* StopStatusEnum.swift in Sources */,

--- a/TMT/TMT/BusJourneyScanned/Models/ScannedJourneyInfo.swift
+++ b/TMT/TMT/BusJourneyScanned/Models/ScannedJourneyInfo.swift
@@ -10,3 +10,4 @@ struct ScannedJourneyInfo {
     var startStop: String
     var endStop: String
 }
+

--- a/TMT/TMT/BusJourneyScanned/Views/NotUploadedView.swift
+++ b/TMT/TMT/BusJourneyScanned/Views/NotUploadedView.swift
@@ -57,6 +57,7 @@ struct NotUploadedView: View {
                             tag = 1
                             path.append("ScannedJourneyInfo")
                         }
+                        pickedItem = nil
                     }
                 }
                 .alert("Failed to recognize the image.", isPresented: $imageHandler.showAlertScreen) {

--- a/TMT/TMT/BusJourneyScanned/Views/ScannedJourneyInfoView.swift
+++ b/TMT/TMT/BusJourneyScanned/Views/ScannedJourneyInfoView.swift
@@ -63,6 +63,9 @@ struct ScannedJourneyInfoView: View {
                             .lineLimit(nil)
                             .fixedSize(horizontal: false, vertical: true)
                     }
+                    .onAppear {
+                        imageHandler.scannedJourneyInfo = ScannedJourneyInfo(busNumber: "", startStop: "", endStop: "")
+                    }
                     .frame(height: 42)
                     .foregroundStyle(.red600)
                 }
@@ -95,8 +98,6 @@ struct ScannedJourneyInfoView: View {
                         Button {
                             showingAlert = false
                             showingPhotosPicker = true
-                            imageHandler.scannedJourneyInfo = ScannedJourneyInfo(busNumber: "", startStop: "", endStop: "")
-                            imageHandler.selectedImage = nil
                         } label: {
                             // TODO: 커스텀 안되는 문제 해결하기
                             Text("Confirm")
@@ -137,7 +138,7 @@ struct ScannedJourneyInfoView: View {
                             
                             guard let startStop = journeyModel.journeyStops.first else { return }
                             guard let endStop = journeyModel.journeyStops.last else { return }
-                          
+                            
                             activityManager.startLiveActivity(startBusStop: startStop, endBusStop: endStop, remainingStops: locationManager.remainingStops)
                             tag = 1
                             path.append("BusStop")


### PR DESCRIPTION
<!--
    [#이슈번호] Title
ex) [#1] PR Templete 생성
-->

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- #119 이 pr에서 충돌을 해결하다가 일부 파일의 reference 또는 파일의 실체가 사라진 것 같습니다.. 분명히 깃허브에는 떠있는데 pull을 받아보니 xcode에는 없는,, 근데 파인더에서 찾아보면 또 있는..? 그런 요상한 에러가 생겼습니다. 그래서 문제가 있었던 파일을 모두 없애고 다시 추가하였습니다..!
- 원래 photospicker 관련한 자잘한 버그를 수정하기 위한 브랜치였습니다😅 그래서 ScannedJourneyInfoView와 NotUploadedView에 소소한 수정이 있습니다.

- ScannedJourneyInfoView
  - Reupload를 했을 때 잘못된 사진을 올리면 사진은 뜨고 아래에 TextField만 빈칸이 뜨게 하였습니다.
  - Reupload 버튼을 눌렀다가 사진을 변경하지 않고 그냥 photospicker 창을 내리는 경우, 기존의 데이터가 그대로 유지되는 방향으로 변경하였습니다.
- NoutUploadedView
  - 선택했던 사진을 저장하는 변수 pickedItem이 ocr을 위해 데이터를 넘겨주면, 이후에는 다시 초기화되도록 하였습니다. -> 다시 사진을 선택하는 경우가 생길 때 같은 사진을 다시 선택할 수 있게 바뀌었습니다. (기존에는 같은 사진 선택이 안됐음.)

### 스크린샷
https://github.com/user-attachments/assets/a7048fe5-1321-45a0-bdfa-3cb7f53eaa59


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 이 브랜치 먼저 approve 내주시면 감사하겠습니다!