### PR TITLE
[#126] 라이브 액티비티 잠금화면 뷰 오류 수정

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -33,9 +33,6 @@
 		5BF33BF52CE70E37006F17EC /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9E9B2CE47F12004F2024 /* Color.swift */; };
 		D801A1BA2CF2213C00AD0D64 /* BusDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801A1B92CF2213C00AD0D64 /* BusDataMock.swift */; };
 		D81238912CF8C0560005EB25 /* TMTShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D81238872CF8C0560005EB25 /* TMTShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		D81238C82CF8CD760005EB25 /* ScannedJourneyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81238C72CF8CD760005EB25 /* ScannedJourneyInfoView.swift */; };
-		D81238C92CF8CD920005EB25 /* ScannedJourneyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B50F1882CE64EB500E2EC41 /* ScannedJourneyInfo.swift */; };
-		D81238CA2CF8CDAE0005EB25 /* EndStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6D2572CD3DD0D00F6A487 /* EndStopView.swift */; };
 		D81D9D3C2CE21CD1004F2024 /* JourneySettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9D3B2CE21CD1004F2024 /* JourneySettingModel.swift */; };
 		D81D9E9A2CE47F0D004F2024 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9E992CE47F0D004F2024 /* String.swift */; };
 		D81D9E9C2CE47F12004F2024 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9E9B2CE47F12004F2024 /* Color.swift */; };
@@ -126,7 +123,6 @@
 		D81238872CF8C0560005EB25 /* TMTShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TMTShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D81238962CF8C07C0005EB25 /* TMTRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TMTRelease.entitlements; sourceTree = "<group>"; };
 		D81238982CF8C3380005EB25 /* TMT.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TMT.entitlements; sourceTree = "<group>"; };
-		D81238C72CF8CD760005EB25 /* ScannedJourneyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedJourneyInfoView.swift; sourceTree = "<group>"; };
 		D81D9D3B2CE21CD1004F2024 /* JourneySettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneySettingModel.swift; sourceTree = "<group>"; };
 		D81D9E992CE47F0D004F2024 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		D81D9E9B2CE47F12004F2024 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };

--- a/TMT/TMTWidget/TMTWidgetLiveActivity.swift
+++ b/TMT/TMTWidget/TMTWidgetLiveActivity.swift
@@ -43,6 +43,8 @@ struct BusJourneyLiveActivity: Widget {
                 }
                 .foregroundStyle(.basicBlack)
                 .multilineTextAlignment(.leading)
+
+                Spacer()
                 
                 Image("TrailingBig")
                     .resizable()
@@ -191,8 +193,8 @@ extension BusJourneyAttributes {
 }
 
 extension BusJourneyAttributes.ContentState {
-    fileprivate static var HyoGokDong55: BusJourneyAttributes.ContentState {
-        BusJourneyAttributes.ContentState(remainingStopsCount: 55, thisStopNameKorean: "효곡동행정복지센터", thisStopNameRomanized: "Hyo-gok-dong Haeng-jeong Bok-ji Center")
+    fileprivate static var Postech55: BusJourneyAttributes.ContentState {
+        BusJourneyAttributes.ContentState(remainingStopsCount: 55, thisStopNameKorean: "포스텍", thisStopNameRomanized: "Postech")
     }
     
     fileprivate static var HyoGokDong3: BusJourneyAttributes.ContentState {
@@ -215,7 +217,7 @@ extension BusJourneyAttributes.ContentState {
 #Preview("Lock Screen", as: .content, using: BusJourneyAttributes.preview) {
     BusJourneyLiveActivity()
 } contentStates: {
-    BusJourneyAttributes.ContentState.HyoGokDong55
+    BusJourneyAttributes.ContentState.Postech55
     BusJourneyAttributes.ContentState.HyoGokDong3
     BusJourneyAttributes.ContentState.HyoGokDong2
     BusJourneyAttributes.ContentState.HyoGokDong1
@@ -225,7 +227,7 @@ extension BusJourneyAttributes.ContentState {
 #Preview("Expanded Dynamic Island", as: .dynamicIsland(.expanded), using: BusJourneyAttributes.preview) {
     BusJourneyLiveActivity()
 } contentStates: {
-    BusJourneyAttributes.ContentState.HyoGokDong55
+    BusJourneyAttributes.ContentState.Postech55
     BusJourneyAttributes.ContentState.HyoGokDong3
     BusJourneyAttributes.ContentState.HyoGokDong2
     BusJourneyAttributes.ContentState.HyoGokDong1
@@ -235,7 +237,7 @@ extension BusJourneyAttributes.ContentState {
 #Preview("Compact Dynamic Island", as: .dynamicIsland(.compact), using: BusJourneyAttributes.preview) {
     BusJourneyLiveActivity()
 } contentStates: {
-    BusJourneyAttributes.ContentState.HyoGokDong55
+    BusJourneyAttributes.ContentState.Postech55
     BusJourneyAttributes.ContentState.HyoGokDong3
     BusJourneyAttributes.ContentState.HyoGokDong2
     BusJourneyAttributes.ContentState.HyoGokDong1
@@ -245,7 +247,7 @@ extension BusJourneyAttributes.ContentState {
 #Preview("Minimal Dynamic Island", as: .dynamicIsland(.minimal), using: BusJourneyAttributes.preview) {
     BusJourneyLiveActivity()
 } contentStates: {
-    BusJourneyAttributes.ContentState.HyoGokDong55
+    BusJourneyAttributes.ContentState.Postech55
     BusJourneyAttributes.ContentState.HyoGokDong3
     BusJourneyAttributes.ContentState.HyoGokDong2
     BusJourneyAttributes.ContentState.HyoGokDong1


### PR DESCRIPTION
<!--
    [#이슈번호] Title
ex) [#1] PR Templete 생성
-->

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 글자 수 적은 정류장명일 때, 정류장 텍스트 정보와 남은 정류장 수 정보 사이 **간격 문제** 해결했습니다!
- 텍스트 정보와 동그라미 사이에 spacer가 빠졌더군요 ..

### 스크린샷
<img width="401" alt="image" src="https://github.com/user-attachments/assets/6781647d-9bf3-488a-a597-2498267e5257">


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 자그마한 수정 PR이라 아마 5초 내로 확인 끝날듯요 . 하하
