### PR TITLE
[#141] 앱 종료할 때 실행 중인 라이브 액티비티도 종료하기

### DIFF
--- a/TMT/TMT/AppDelegate.swift
+++ b/TMT/TMT/AppDelegate.swift
@@ -17,4 +17,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound])
     }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        LiveActivityManager.shared.endLiveActivity()
+    }
 }

--- a/TMT/TMT/BusJourneyScanned/Views/ScannedJourneyInfoView.swift
+++ b/TMT/TMT/BusJourneyScanned/Views/ScannedJourneyInfoView.swift
@@ -13,7 +13,6 @@ struct ScannedJourneyInfoView: View {
     @EnvironmentObject var locationManager: LocationManager
     @EnvironmentObject var searchModel: BusSearchModel
     @EnvironmentObject var journeyModel: JourneySettingModel
-    @EnvironmentObject var activityManager: LiveActivityManager
 
     @State private var tag: Int? = nil
 
@@ -128,7 +127,7 @@ struct ScannedJourneyInfoView: View {
                                 guard let startStop = journeyModel.journeyStops.first else { return }
                                 guard let endStop = journeyModel.journeyStops.last else { return }
 
-                                activityManager.startLiveActivity(startBusStop: startStop, endBusStop: endStop, remainingStops: locationManager.remainingStops)
+                                LiveActivityManager.shared.startLiveActivity(startBusStop: startStop, endBusStop: endStop, remainingStops: locationManager.remainingStops)
 
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                                     isLoading = false

--- a/TMT/TMT/HomeView.swift
+++ b/TMT/TMT/HomeView.swift
@@ -10,7 +10,6 @@ import PhotosUI
 
 struct HomeView: View {
     @AppStorage("shouldShowOnboarding") var shouldShowOnboarding = true
-    @StateObject private var activityManager: LiveActivityManager
     @StateObject private var journeyModel: JourneySettingModel
     @StateObject private var imageHandler: ImageHandlerModel = ImageHandlerModel()
     @StateObject private var locationManager: LocationManager
@@ -23,12 +22,10 @@ struct HomeView: View {
     init() {
         let searchModel = BusSearchModel()
         let journeyModel = JourneySettingModel(searchModel: searchModel)
-        let activityManager = LiveActivityManager()
         
         _searchModel = StateObject(wrappedValue: searchModel)
         _journeyModel = StateObject(wrappedValue: journeyModel)
-        _activityManager = StateObject(wrappedValue: activityManager)
-        _locationManager = StateObject(wrappedValue: LocationManager(activityManager: activityManager, journeyModel: journeyModel))
+        _locationManager = StateObject(wrappedValue: LocationManager(journeyModel: journeyModel))
     }
     
     var body: some View {
@@ -71,7 +68,6 @@ struct HomeView: View {
         }
         .environmentObject(locationManager)
         .environmentObject(searchModel)
-        .environmentObject(activityManager)
         .environmentObject(journeyModel)
         .environmentObject(imageHandler)
     }

--- a/TMT/TMT/Map/Views/BusStopArrivalView.swift
+++ b/TMT/TMT/Map/Views/BusStopArrivalView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct BusStopArrivalView: View {
-    @EnvironmentObject var activityManager: LiveActivityManager
     @EnvironmentObject var imageHandler: ImageHandlerModel
     @EnvironmentObject var journeyModel: JourneySettingModel
     @Binding var hasNotArrived: Bool
@@ -45,7 +44,7 @@ struct BusStopArrivalView: View {
                 .padding(.bottom, 8)
             
             FilledButton(title: "End") {
-                activityManager.endLiveActivity()
+                LiveActivityManager.shared.endLiveActivity()
                 imageHandler.selectedImage = nil
                 hasNotArrived = false
                 path.removeAll()

--- a/TMT/TMT/Map/Views/BusStopArrivalView.swift
+++ b/TMT/TMT/Map/Views/BusStopArrivalView.swift
@@ -45,7 +45,7 @@ struct BusStopArrivalView: View {
                 .padding(.bottom, 8)
             
             FilledButton(title: "End") {
-                activityManager.endLiveActivity(destinationInfo: journeyModel.journeyStops.last!)
+                activityManager.endLiveActivity()
                 imageHandler.selectedImage = nil
                 hasNotArrived = false
                 path.removeAll()

--- a/TMT/TMT/Map/Views/MapView.swift
+++ b/TMT/TMT/Map/Views/MapView.swift
@@ -12,7 +12,6 @@ struct MapView: View {
     @EnvironmentObject var searchModel: BusSearchModel
     @EnvironmentObject var journeyModel: JourneySettingModel
     @StateObject var selectedStopManager = SelectedStopManager()
-    @EnvironmentObject var activityManager: LiveActivityManager
     @EnvironmentObject var imageHandler: ImageHandlerModel
     
     @State private var colors: (statusColor: Color, leftStopNumberColor: Color, destinationColor: Color) = (.white, .white, .white)
@@ -162,7 +161,7 @@ struct MapView: View {
                 showingAlert = false
             }
             Button("End", role:.destructive) {
-                activityManager.endLiveActivity()
+                LiveActivityManager.shared.endLiveActivity()
                 imageHandler.selectedImage = nil
                 isShowingBottomSheet = false
                 path.removeAll()
@@ -205,9 +204,8 @@ struct MapView: View {
     // Mock 데이터 및 객체 초기화
     let searchModel = BusSearchModel()
     let journeyModel = JourneySettingModel(searchModel: searchModel)
-    let activityManager = LiveActivityManager()
     let imageHandler = ImageHandlerModel()
-    let locationManager = LocationManager(activityManager: activityManager, journeyModel: journeyModel)
+    let locationManager = LocationManager(journeyModel: journeyModel)
     
     searchModel.filteredBusDataForNumber = BusStop.busStopDummy
     
@@ -217,6 +215,5 @@ struct MapView: View {
         .environmentObject(locationManager)
         .environmentObject(searchModel)
         .environmentObject(journeyModel)
-        .environmentObject(activityManager)
         .environmentObject(imageHandler)
 }

--- a/TMT/TMT/Map/Views/MapView.swift
+++ b/TMT/TMT/Map/Views/MapView.swift
@@ -162,7 +162,7 @@ struct MapView: View {
                 showingAlert = false
             }
             Button("End", role:.destructive) {
-                activityManager.endLiveActivity(destinationInfo: journeyModel.journeyStops.last!)
+                activityManager.endLiveActivity()
                 imageHandler.selectedImage = nil
                 isShowingBottomSheet = false
                 path.removeAll()

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -5,10 +5,9 @@
 //  Created by 김유빈 on 10/17/24.
 //
 
-import Combine
 import ActivityKit
 
-final class LiveActivityManager: ObservableObject {
+final class LiveActivityManager {
     static let shared = LiveActivityManager()
 
     private var activity: Activity<BusJourneyAttributes>?

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -6,6 +6,7 @@
 //
 
 import ActivityKit
+import SwiftUI
 
 final class LiveActivityManager {
     static let shared = LiveActivityManager()
@@ -38,13 +39,18 @@ final class LiveActivityManager {
     }
     
     func endLiveActivity() {
+        let semaphore = DispatchSemaphore(value: 0)
+
         Task {
-            for activity in Activity<BusJourneyAttributes>.activities {
-                await activity.end(nil, dismissalPolicy: .immediate)
+            if let currentActivity = activity {
+                await currentActivity.end(nil, dismissalPolicy: .immediate)
+                self.activity = nil
             }
 
-            activity = nil
+            semaphore.signal()
         }
+
+        semaphore.wait()
     }
     
     func updateLiveActivity(remainingStops: Int, thisStop: BusStop) async {

--- a/TMT/TMT/Utils/LiveActivityManager.swift
+++ b/TMT/TMT/Utils/LiveActivityManager.swift
@@ -9,6 +9,8 @@ import Combine
 import ActivityKit
 
 final class LiveActivityManager: ObservableObject {
+    static let shared = LiveActivityManager()
+
     private var activity: Activity<BusJourneyAttributes>?
     
     func startLiveActivity(startBusStop: BusStop, endBusStop: BusStop, remainingStops: Int) {
@@ -36,17 +38,12 @@ final class LiveActivityManager: ObservableObject {
         
     }
     
-    func endLiveActivity(destinationInfo: BusStop) {
-        guard let destinationNameKorean = destinationInfo.stopNameKorean else { return }
-        guard let destinationNameRomanized = destinationInfo.stopNameRomanized else { return }
-        
-        let finalContent = BusJourneyAttributes.ContentState(remainingStopsCount: 0, thisStopNameKorean: destinationNameKorean, thisStopNameRomanized: destinationNameRomanized)
-        
-        let dismissalpolicy: ActivityUIDismissalPolicy = .immediate
-        
+    func endLiveActivity() {
         Task {
-            await activity?.end(ActivityContent(state: finalContent, staleDate: nil), dismissalPolicy: dismissalpolicy)
-            
+            for activity in Activity<BusJourneyAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+
             activity = nil
         }
     }

--- a/TMT/TMT/Utils/LocationManager.swift
+++ b/TMT/TMT/Utils/LocationManager.swift
@@ -22,7 +22,7 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             if oldValue != remainingStops {
                 Task {
                     if let currentStop = thisStop {
-                        await activityManager?.updateLiveActivity(remainingStops: remainingStops, thisStop: currentStop)
+                        await LiveActivityManager.shared.updateLiveActivity(remainingStops: remainingStops, thisStop: currentStop)
                     } else {
                         print("❌ 현재 정류장 정보가 없습니다.")
                     }
@@ -35,11 +35,9 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var showSettingsAlert = false
     
     private let locationManager = CLLocationManager()
-    private weak var activityManager: LiveActivityManager?
     private weak var journeyModel: JourneySettingModel?
     
-    init(activityManager: LiveActivityManager, journeyModel: JourneySettingModel) {
-        self.activityManager = activityManager
+    init(journeyModel: JourneySettingModel) {
         self.journeyModel = journeyModel
         self.thisStop = journeyModel.journeyStops.first
         super.init()


### PR DESCRIPTION
<!--
    [#이슈번호] Title
ex) [#1] PR Templete 생성
-->

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요


- LiveActivityManager를 싱글톤 패턴으로 변경
기존에는 LiveActivityManager를 `ObservableObject`로 사용하고, 최상위 뷰에서 `@StateObject`로 선언 후 하위 뷰에 `@EnvironmentObject`로 주입하는 방식이었습니다.
이를 싱글톤 패턴으로 변경하여 전역적으로 관리되도록 수정했습니다.
이 변경으로 코드의 흐름과 가독성을 개선하고, 관리의 효율성을 높였습니다.


- `AppDelegate`에 앱 종료 시 실행되는 메서드 추가
`applicationWillTerminate` 메서드에 라이브 액티비티 종료 함수를 호출하는 로직을 추가했습니다.

- 라이브 액티비티 종료 함수 리팩토링
  1. 불필요한 파라미터 제거
  기존에는 도착 정류장 데이터를 파라미터로 전달했으나, 불필요한 데이터임을 확인하여 이를 제거했습니다.
  
  2. 세마포어를 사용해 비동기 작업을 동기적으로 처리
  앱 종료 시 라이브 액티비티 종료 함수가 호출되더라도, 비동기적으로 처리하면 종료 시점에 라이브 액티비티가 종료되지 않을 수 있습니다.
  이를 해결하기 위해 세마포어를 사용하여 라이브 액티비티가 종료된 후에 앱이 종료되도록 수정했습니다.


### 스크린샷
<img src="https://github.com/user-attachments/assets/66b2a82d-ed74-40e1-8d2d-112b5498a299" width="300"/>
